### PR TITLE
API: Version viewing on DataObjects

### DIFF
--- a/code/models/BaseElement.php
+++ b/code/models/BaseElement.php
@@ -14,9 +14,9 @@ class BaseElement extends Widget {
 		'List' => 'ElementList' // optional.
 	);
 
- 	/**
+	 /**
 	 * @var string
-	*/
+	 */
 	private static $title = "Base Element";
 
 	/**
@@ -81,7 +81,25 @@ class BaseElement extends Widget {
 
 		$this->extend('updateCMSFields', $fields);
 
+		if ($this->IsInDB()) {
+			if ($this->isEndofLine('BaseElement') && $this->hasExtension('VersionViewerDataObject')) {
+				$fields = $this->addVersionViewer($fields, $this);
+			}
+		}
+
 		return $fields;
+	}
+
+	/**
+	 * Version viewer must only be added at if this is the final getCMSFields for a class.
+	 * in order to avoid having to rename all fields from eg Root.Main to Root.Current.Main
+	 * To do this we test if getCMSFields is from the current class
+	 */
+	public function isEndofLine($className) {
+		$methodFromClass = ClassInfo::has_method_from($this->ClassName, 'getCMSFields', $className);
+		if($methodFromClass) {
+			return true;
+		}
 	}
 
 	public function onBeforeWrite() {

--- a/code/models/ElementContent.php
+++ b/code/models/ElementContent.php
@@ -33,6 +33,10 @@ class ElementContent extends BaseElement {
 			$fields->removeByName('Style');
 		}
 
+		if ($this->isEndofLine('ElementContent') && $this->hasExtension('VersionViewerDataObject')) {
+			$fields = $this->addVersionViewer($fields, $this);
+		}
+
 		return $fields;
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
 		"heyday/silverstripe-versioneddataobjects": "dev-master",
 		"undefinedoffset/sortablegridfield": "dev-master"
 	},
+	"suggest": {
+		"bluehousegroup/silverstripe-data-object-version-viewer": "Allows viewing of version history for data objects inside of the SilverStripe CMS"
+	},
 	"extra": {
 		"installer-name": "elemental"
 	}


### PR DESCRIPTION
When silverstripe-data-object-version-viewer is installed, adds ability to view history in data objects to ElementContent, and BaseElement. Adds a check to BaseElement to determine if history fields should be added.

WARNING: because this changes field names (Root.Main becomes Root.Current.Main), there could be some integration required on upgrade if you have used extensions with updateCMSFields on ElementContent, or BaseElement. 