### PR TITLE
FIX Ignore content generation Requirements calls

### DIFF
--- a/code/extensions/ElementPageExtension.php
+++ b/code/extensions/ElementPageExtension.php
@@ -138,6 +138,7 @@ class ElementPageExtension extends DataExtension
                 // Copy widgets content to Content to enable search
                 $searchableContent = array();
 
+                Requirements::clear();
                 foreach ($elements->Elements() as $element) {
                     if ($element->config()->exclude_from_content) {
                         continue;
@@ -151,6 +152,7 @@ class ElementPageExtension extends DataExtension
                         array_push($searchableContent, $controller->WidgetHolder());
                     }
                 }
+                Requirements::restore();
 
                 $this->owner->Content = trim(implode(' ', $searchableContent));
             }


### PR DESCRIPTION
If an element declares some Requirements during its rendering, these
requirements get bound to the ajax request during a 'save' call from the
cms, and can then filter through to the CMS UI. This clears out any added
during the Content population process