### PR TITLE
Virtual updates

### DIFF
--- a/code/controllers/BaseElementController.php
+++ b/code/controllers/BaseElementController.php
@@ -17,4 +17,32 @@ class BaseElement_Controller extends WidgetController
     {
         return $this->renderWith("ElementHolder");
     }
+
+
+    public function Link($action = null)
+    {
+
+        if($this->data()->virtualOwner) {
+          $controller = new BaseElement_Controller($this->data()->virtualOwner);
+          return $controller->Link($action);
+        }
+
+        return Parent::Link($action);
+    }
+
+
+    /**
+     * if this is a virtual request, change the hash if set.
+     */
+    public function redirect($url, $code=302) {
+
+      if($this->data()->virtualOwner) {
+        $parts = explode('#', $url);
+        if(isset($parts[1])) {
+          $url = $parts[0] . '#' . $this->data()->virtualOwner->ID;
+        }
+      }
+
+      return parent::redirect($url, $code);
+    }
 }

--- a/code/extensions/BaseElementExtension.php
+++ b/code/extensions/BaseElementExtension.php
@@ -38,4 +38,32 @@ class BaseElementExtension extends VersionedDataObject
     {
         return (Permission::check('CMS_ACCESS_CMSMain', 'any', $member)) ? true : null;
     }
+
+    /**
+     * Handles unpublishing as VersionedDataObjects doesn't
+     * Modelled on SiteTree::doUnpublish
+     *
+     */
+    public function doUnpublish() {
+        if(!$this->owner->ID) return false;
+
+        $this->owner->extend('onBeforeUnpublish');
+
+        $origStage = Versioned::get_reading_mode();
+        Versioned::set_reading_mode('Stage.Live');
+
+        // This way our ID won't be unset
+        $clone = clone $this->owner;
+        $clone->delete();
+
+        Versioned::set_reading_mode($origStage);
+
+        $virtualLinkedElements = $this->owner->getPublishedVirtualLinkedElements();
+        if ($virtualLinkedElements) foreach($virtualLinkedElements as $vle) $vle->doUnpublish();
+
+        $this->owner->extend('onAfterUnpublish');
+
+        return true;
+    }
+
 }

--- a/code/extensions/ElementPageExtension.php
+++ b/code/extensions/ElementPageExtension.php
@@ -104,6 +104,9 @@ class ElementPageExtension extends DataExtension
             $autocomplete->setSearchList(BaseElement::get()->filter('ClassName', array_keys($list)));
         }
 
+        $autocomplete->setResultsFormat('($ID) $Title');
+        $autocomplete->setSearchFields(array('ID', 'Title'));
+
         $config = $gridField->getConfig();
         $paginator = $config->getComponentByType('GridFieldPaginator');
         $paginator->setItemsPerPage(100);

--- a/code/extensions/ElementPageExtension.php
+++ b/code/extensions/ElementPageExtension.php
@@ -228,6 +228,48 @@ class ElementPageExtension extends DataExtension
     }
 
     /**
+     * Ensure that if there are elements that belong to this page
+     * and are virtualised (Virtual Element links to them), that we move the
+     * original element to replace one of the virtual elements
+     * But only if it's a delete not an unpublish
+     */
+    public function onAfterDelete() {
+        if(Versioned::get_reading_mode() == 'Stage.Stage') {
+            $area = $this->owner->ElementArea();
+            foreach ($area->Widgets() as $element) {
+                $firstVirtual = false;
+                if ($element->getPublishedVirtualLinkedElements()->Count() > 0) {
+                    // choose the first one
+                    $firstVirtual = $element->getPublishedVirtualLinkedElements()->First();
+                    $wasPublished = true;
+                } else if ($element->getVirtualLinkedElements()->Count() > 0) {
+                    // choose the first one
+                    $firstVirtual = $element->getVirtualLinkedElements()->First();
+                    $wasPublished = false;
+                }
+                if ($firstVirtual) {
+                    $origParentID = $element->ParentID;
+                    $origSort = $element->Sort;
+
+                    // change element to first's values
+                    $element->ParentID = $firstVirtual->ParentID;
+                    $element->Sort = $firstVirtual->Sort;
+
+                    $firstVirtual->ParentID = $origParentID;
+                    $firstVirtual->Sort = $origSort;
+                    // write
+                    $element->write();
+                    $firstVirtual->write();
+                    if ($wasPublished) {
+                        $element->doPublish();
+                        $firstVirtual->doPublish();
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * @return boolean
      */
     public function supportsElemental() {

--- a/code/models/BaseElement.php
+++ b/code/models/BaseElement.php
@@ -63,6 +63,12 @@ class BaseElement extends Widget
      */
     private static $enable_title_in_template = false;
 
+    /**
+     * @var Object
+     * The virtual owner VirtualLinkedElement
+     */
+    public $virtualOwner;
+
 
     public function getCMSFields()
     {
@@ -231,6 +237,10 @@ class BaseElement extends Widget
 
     public function getPage()
     {
+        if ($this->virtualOwner) {
+            return $this->virtualOwner->getPage();
+        }
+
         $area = $this->Parent();
 
         if ($area instanceof ElementalArea) {
@@ -268,7 +278,7 @@ class BaseElement extends Widget
 
     }
 
-    public static function all_allowed_elements() {
+		public static function all_allowed_elements() {
         $classes = array();
 
         // get all dataobject with the elemental extension
@@ -316,4 +326,30 @@ class BaseElement extends Widget
             $filters
         );
     }
+
+    public function setVirtualOwner(ElementVirtualLinked $virtualOwner) {
+        $this->virtualOwner = $virtualOwner;
+    }
+
+    /**
+     * Finds and returns elements
+     * that are virtual elements which link to this element
+     */
+    public function getVirtualLinkedElements() {
+        return ElementVirtualLinked::get()->filter('LinkedElementID', $this->ID);
+    }
+
+    /**
+     * Finds and returns published elements
+     * that are virtual elements which link to this element
+     */
+    public function getPublishedVirtualLinkedElements() {
+        $current = Versioned::get_reading_mode();
+        Versioned::set_reading_mode('Stage.Live');
+        $v = $this->getVirtualLinkedElements();
+        Versioned::set_reading_mode($current);
+        return $v;
+    }
 }
+
+

--- a/code/models/ElementVirtualLinked.php
+++ b/code/models/ElementVirtualLinked.php
@@ -36,6 +36,11 @@ class ElementVirtualLinked extends BaseElement {
         return _t(__CLASS__, $this->LinkedElement()->config()->title);
     }
 
+    public function __construct($record = null, $isSingleton = false, $model = null) {
+        parent::__construct($record, $isSingleton, $model);
+        $this->LinkedElement()->setVirtualOwner($this);
+    }
+
     public function getCMSFields() {
         $message = sprintf('<p>%s</p><p><a href="%2$s">%2$s</a></p>',
              _t('ElementVirtualLinked.DESCRIBE', 'This is a virtual copy of a block. To edit, visit'),
@@ -55,7 +60,68 @@ class ElementVirtualLinked extends BaseElement {
         return $fields;
     }
 
-    public function getExtraClass() {
-        return $this->LinkedElement()->ClassName . ' ' . $this->getField('ExtraClass');
+}
+
+class ElementVirtualLinked_Controller extends BaseElement_Controller {
+
+    protected $controllerClass;
+
+    public function __construct($widget) {
+        parent::__construct($widget);
+
+        $controllerClass = get_class($this->LinkedElement()) . '_Controller';
+        if(class_exists($controllerClass)) {
+            $this->controllerClass = $controllerClass;
+        } else {
+            $this->controllerClass = 'BaseElement_Controller';
+        }
+    }
+
+    /**
+     * Returns the current widget in scope rendered into its' holder
+     *
+     * @return HTML
+     */
+    public function WidgetHolder()
+    {
+        return $this->renderWith("ElementHolder_VirtualLinked");
+    }
+
+    public function __call($method, $arguments) {
+        try {
+           $retVal = parent::__call($method, $arguments);
+
+        } catch (Exception $e) {
+            $controller = new $this->controllerClass($this->LinkedElement());
+            $retVal = call_user_func_array(array($controller, $method), $arguments);
+        }
+        return $retVal;
+    }
+
+    public function hasMethod($action) {
+        if(parent::hasMethod($action)) {
+            return true;
+        }
+
+        $controller = new $this->controllerClass($this->LinkedElement());
+        return $controller->hasMethod($action);
+    }
+
+    public function hasAction($action) {
+        if(parent::hasAction($action)) {
+            return true;
+        }
+
+        $controller = new $this->controllerClass($this->LinkedElement());
+        return $controller->hasAction($action);
+    }
+
+    public function checkAccessAction($action) {
+        if(parent::checkAccessAction($action)) {
+            return true;
+        }
+
+        $controller = new $this->controllerClass($this->LinkedElement());
+        return $controller->checkAccessAction($action);
     }
 }

--- a/templates/ElementHolder_VirtualLinked.ss
+++ b/templates/ElementHolder_VirtualLinked.ss
@@ -1,0 +1,3 @@
+<div class="element $ClassName $LinkedElement.ClassName<% if $LinkedElement.ExtraClass %> $LinkedElement.ExtraClass<% end_if %>" id="e{$LinkedElement.ID}">
+	$Widget
+</div>


### PR DESCRIPTION
made virtualised elements more transparent

enables virtualised elements to handle forms and the like much more seamlessly

handling page and element deleting with virtualising

Ensures element moves to new page if page is deleted, and recreates element if original is deleted when being virtualised
