### PR TITLE
FIX: ElementalSolrIndexer  variable missing

### DIFF
--- a/code/search/ElementalSolrIndexer.php
+++ b/code/search/ElementalSolrIndexer.php
@@ -29,9 +29,9 @@ class ElementalSolrIndexer {
                     $dirty[$clone->ID] = $clone->ID;
                 }
             }
-        }
 
-        $this->publishDirtyClones($dirty);
+             $this->publishDirtyClones($dirty);
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes the `[Notice] Undefined variable: dirty` and `[Warning] Invalid argument supplied for foreach()` on dev/build and page publish.