### PR TITLE
feat(BaseElement): Add 'getAnchor' function

### DIFF
--- a/code/models/BaseElement.php
+++ b/code/models/BaseElement.php
@@ -63,6 +63,27 @@ class BaseElement extends Widget
      */
     private static $enable_title_in_template = false;
 
+    /**
+     * Enable for backwards compatibility
+     * 
+     * @var boolean
+     */
+    private static $disable_pretty_anchor_name = false;
+
+    /**
+     * Store used anchor names, this is to avoid title clashes
+     * when calling 'getAnchor'
+     *
+     * @var array
+     */
+    protected static $_used_anchors = array();
+
+    /**
+     * For caching 'getAnchor'
+     *
+     * @var string
+     */
+    protected $_anchor = null;
 
     public function getCMSFields()
     {
@@ -207,6 +228,43 @@ class BaseElement extends Widget
 
             return $this->config()->title;
         }
+    }
+
+    /**
+     * Get a unique anchor name
+     *
+     * @return string
+     */
+    public function getAnchor() {
+        if ($this->_anchor !== null) {
+            return $this->_anchor;
+        }
+
+        $anchorTitle = '';
+        if (!$this->config()->disable_pretty_anchor_name) {
+            if ($this->hasMethod('getAnchorTitle')) {
+                $anchorTitle = $this->getAnchorTitle();
+            } else if ($this->config()->enable_title_in_template) {
+                $anchorTitle = $this->getField('Title');
+            }
+        }
+        if (!$anchorTitle) {
+            $anchorTitle = 'e'.$this->ID;
+        }
+
+        $filter = URLSegmentFilter::create();
+        $titleAsURL = $filter->filter($anchorTitle);
+
+        // Ensure that this anchor name isn't already in use
+        // ie. If two elemental blocks have the same title, it'll append '-2', '-3'
+        $result = $titleAsURL;
+        $count = 1;
+        while (isset(self::$_used_anchors[$result]) && self::$_used_anchors[$result] !== $this->ID) {
+            ++$count;
+            $result = $titleAsURL.'-'.$count;
+        }
+        self::$_used_anchors[$result] = $this->ID;
+        return $this->_anchor = $result;
     }
 
     /**

--- a/templates/ElementHolder.ss
+++ b/templates/ElementHolder.ss
@@ -1,3 +1,3 @@
-<div class="element $ClassName<% if $ExtraClass %> $ExtraClass<% end_if %>" id="e{$ID}">
+<div class="element $ClassName<% if $ExtraClass %> $ExtraClass<% end_if %>" id="$Anchor">
     $Widget
 </div>

--- a/tests/ElementAnchorTests.php
+++ b/tests/ElementAnchorTests.php
@@ -7,13 +7,11 @@
 class ElementAnchorTests extends FunctionalTest {
     public function setUp() {
         parent::setUp();
-
-        // Reset
-        Config::inst()->update('BaseElement', 'disable_pretty_anchor_name', false);
-        Config::inst()->update('BaseElement', 'enable_title_in_template', false);
-        _used_anchors
     }
 
+    /**
+     * Test to ensure backwards compatibility with old Anchor IDs.
+     */
     public function testDisablePrettyAnchor() {
         Config::inst()->update('BaseElement', 'disable_pretty_anchor_name', true);
 
@@ -25,15 +23,15 @@ class ElementAnchorTests extends FunctionalTest {
         $area->write();
 
         $recordSet = $area->Elements()->toArray();
-        foreach ($recordSet as $record) {
-            $record->getAnchor();
-        }
-        $this->assertEquals('element-1', $recordSet[0]->getAnchor());
-        $this->assertEquals('element-1-2', $recordSet[1]->getAnchor());
-        $this->assertEquals('element-1-3', $recordSet[2]->getAnchor());
-        $this->assertEquals('element-1-4', $recordSet[3]->getAnchor());
+        $this->assertEquals('e'.$recordSet[0]->ID, $recordSet[0]->getAnchor());
+        $this->assertEquals('e'.$recordSet[1]->ID, $recordSet[1]->getAnchor());
+        $this->assertEquals('e'.$recordSet[2]->ID, $recordSet[2]->getAnchor());
+        $this->assertEquals('e'.$recordSet[3]->ID, $recordSet[3]->getAnchor());
     }
 
+    /**
+     * Test the stop-clashing logic if two BaseElement classes have the same $Title.
+     */
     public function testSameTitle() {
         Config::inst()->update('BaseElement', 'enable_title_in_template', true);
 
@@ -46,6 +44,8 @@ class ElementAnchorTests extends FunctionalTest {
 
         $recordSet = $area->Elements()->toArray();
         foreach ($recordSet as $record) {
+            // NOTE: This puts it into the $_anchor protected variable
+            //       and caches it.
             $record->getAnchor();
         }
         $this->assertEquals('element-1', $recordSet[0]->getAnchor());

--- a/tests/ElementAnchorTests.php
+++ b/tests/ElementAnchorTests.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @package elemental
+ * @subpackage tests
+ */
+class ElementAnchorTests extends FunctionalTest {
+    public function setUp() {
+        parent::setUp();
+
+        // Reset
+        Config::inst()->update('BaseElement', 'disable_pretty_anchor_name', false);
+        Config::inst()->update('BaseElement', 'enable_title_in_template', false);
+        _used_anchors
+    }
+
+    public function testDisablePrettyAnchor() {
+        Config::inst()->update('BaseElement', 'disable_pretty_anchor_name', true);
+
+        $area = ElementalArea::create();
+        $area->Widgets()->add(BaseElement::create(array('Title' => 'Element 1', 'Sort' => 1)));
+        $area->Widgets()->add(BaseElement::create(array('Title' => 'Element 1', 'Sort' => 2)));
+        $area->Widgets()->add(BaseElement::create(array('Title' => 'Element 1', 'Sort' => 3)));
+        $area->Widgets()->add(BaseElement::create(array('Title' => 'Element 1', 'Sort' => 4)));
+        $area->write();
+
+        $recordSet = $area->Elements()->toArray();
+        foreach ($recordSet as $record) {
+            $record->getAnchor();
+        }
+        $this->assertEquals('element-1', $recordSet[0]->getAnchor());
+        $this->assertEquals('element-1-2', $recordSet[1]->getAnchor());
+        $this->assertEquals('element-1-3', $recordSet[2]->getAnchor());
+        $this->assertEquals('element-1-4', $recordSet[3]->getAnchor());
+    }
+
+    public function testSameTitle() {
+        Config::inst()->update('BaseElement', 'enable_title_in_template', true);
+
+        $area = ElementalArea::create();
+        $area->Widgets()->add(BaseElement::create(array('Title' => 'Element 1', 'Sort' => 1)));
+        $area->Widgets()->add(BaseElement::create(array('Title' => 'Element 1', 'Sort' => 2)));
+        $area->Widgets()->add(BaseElement::create(array('Title' => 'Element 1', 'Sort' => 3)));
+        $area->Widgets()->add(BaseElement::create(array('Title' => 'Element 1', 'Sort' => 4)));
+        $area->write();
+
+        $recordSet = $area->Elements()->toArray();
+        foreach ($recordSet as $record) {
+            $record->getAnchor();
+        }
+        $this->assertEquals('element-1', $recordSet[0]->getAnchor());
+        $this->assertEquals('element-1-2', $recordSet[1]->getAnchor());
+        $this->assertEquals('element-1-3', $recordSet[2]->getAnchor());
+        $this->assertEquals('element-1-4', $recordSet[3]->getAnchor());
+    }
+}


### PR DESCRIPTION
Add 'getAnchor' function which uses 'getAnchorTitle' or falls back $Title (if enable_title_in_template is true) or falls back to 'e.$this->ID' for backwards compatibility.

This a breaking change, so to retain backwards compatibility, users can disable pretty anchor links with:
```
BaseElement:
  disable_pretty_anchor_name: true
```