### PR TITLE
Add "Available Globally" setting to elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ classes:
 	    - 'image_small' : 'Small'
 ````
 
+### Limiting global elements
+
+By default any element is available to be linked to multiple pages. This can be
+changed with the "Available globally" checkbox in the settings tab of each element.
+The default can be changed so that global elements are opt-in:
+````
+	BaseElement:
+	  default_global_elements: false
+````
+
 ### Defining your own elements.
 
 An element is as simple as a class which extends `BaseElement`. After you add the class, ensure you have rebuilt your

--- a/code/extensions/ElementPageExtension.php
+++ b/code/extensions/ElementPageExtension.php
@@ -100,9 +100,11 @@ class ElementPageExtension extends DataExtension
                 ->addComponent(new GridFieldSortableRows('Sort'))
         );
 
+        $searchList = BaseElement::get()->filter('AvailableGlobally', true);
         if($list) {
-            $autocomplete->setSearchList(BaseElement::get()->filter('ClassName', array_keys($list)));
+            $searchList = $searchList->filter('ClassName', array_keys($list));
         }
+        $autocomplete->setSearchList($searchList);
 
         $autocomplete->setResultsFormat('($ID) $Title');
         $autocomplete->setSearchFields(array('ID', 'Title'));

--- a/code/models/BaseElement.php
+++ b/code/models/BaseElement.php
@@ -10,7 +10,8 @@ class BaseElement extends Widget
      */
     private static $db = array(
         'ExtraClass' => 'Varchar(255)',
-        'HideTitle' => 'Boolean'
+        'HideTitle' => 'Boolean',
+        'AvailableGlobally' => 'Boolean'
     );
 
     /**
@@ -55,7 +56,8 @@ class BaseElement extends Widget
         ),
         'Title',
         'LastEdited',
-        'ClassName'
+        'ClassName',
+        'AvailableGlobally'
     );
 
     /**
@@ -65,7 +67,7 @@ class BaseElement extends Widget
 
     /**
      * Enable for backwards compatibility
-     * 
+     *
      * @var boolean
      */
     private static $disable_pretty_anchor_name = false;
@@ -105,6 +107,7 @@ class BaseElement extends Widget
         $fields->removeByName('ParentID');
         $fields->removeByName('Sort');
         $fields->removeByName('ExtraClass');
+        $fields->removeByName('AvailableGlobally');
 
         if (!$this->config()->enable_title_in_template) {
             $fields->removeByName('HideTitle');
@@ -116,6 +119,7 @@ class BaseElement extends Widget
         }
 
         $fields->addFieldToTab('Root.Settings', new TextField('ExtraClass', 'Extra CSS Classes to add'));
+        $fields->addFieldToTab('Root.Settings', new CheckboxField('AvailableGlobally', 'Available globally - can be linked to multiple pages'));
 
         if (!is_a($this, 'ElementList')) {
             $lists = ElementList::get()->filter('ParentID', $this->ParentID);
@@ -376,9 +380,9 @@ class BaseElement extends Widget
     public function forTemplate($holder = true)
     {
         $config = SiteConfig::current_site_config();
-        
+
         if ($config->Theme) Config::inst()->update('SSViewer', 'theme', $config->Theme);
-        
+
         return $this->renderWith($this->class);
     }
 
@@ -472,5 +476,3 @@ class BaseElement extends Widget
         return $v;
     }
 }
-
-

--- a/code/models/BaseElement.php
+++ b/code/models/BaseElement.php
@@ -11,7 +11,7 @@ class BaseElement extends Widget
     private static $db = array(
         'ExtraClass' => 'Varchar(255)',
         'HideTitle' => 'Boolean',
-        'AvailableGlobally' => 'Boolean'
+        'AvailableGlobally' => 'Boolean(1)'
     );
 
     /**
@@ -93,6 +93,16 @@ class BaseElement extends Widget
      */
     public $virtualOwner;
 
+    /**
+     * @config
+     * Elements available globally by default
+     */
+     private static $default_global_elements = true;
+
+     public function populateDefaults() {
+        $this->AvailableGlobally = $this->config()->get('default_global_elements');
+        parent::populateDefaults();
+     }
 
     public function getCMSFields()
     {


### PR DESCRIPTION
The majority of elements being used in a project are often only used on a single page. This change adds a checkbox in an elements settings, and only elements that opt-in will appear in the autocomplete list to be linked to another page.

By default all elements are available globally, to ensure backwards compatibility. This can be changed with a config option that is detailed in the README.