### PR TITLE
Use anchor feature for virtual linked elements

### DIFF
--- a/code/models/ElementVirtualLinked.php
+++ b/code/models/ElementVirtualLinked.php
@@ -102,6 +102,23 @@ class ElementVirtualLinked extends BaseElement
         }
         return $publishedState;
     }
+
+
+    /**
+     * Get a unique anchor name
+     *
+     * @return string
+     */
+    public function getAnchor() {
+        $linkedElement = $this->LinkedElement();
+
+        if ($linkedElement && $linkedElement->exists()) {
+            return $linkedElement->getAnchor();
+        }
+
+        // generic fallback
+        return 'e'.$this->ID;
+    }
 }
 
 class ElementVirtualLinked_Controller extends BaseElement_Controller

--- a/templates/ElementHolder_VirtualLinked.ss
+++ b/templates/ElementHolder_VirtualLinked.ss
@@ -1,3 +1,3 @@
-<div class="element $ClassName $LinkedElement.ClassName<% if $LinkedElement.ExtraClass %> $LinkedElement.ExtraClass<% end_if %>" id="e{$LinkedElement.ID}">
-	$Widget
+<div class="element $ClassName $LinkedElement.ClassName<% if $LinkedElement.ExtraClass %> $LinkedElement.ExtraClass<% end_if %>" id="$Anchor">
+    $Widget
 </div>

--- a/tests/ElementAnchorTests.php
+++ b/tests/ElementAnchorTests.php
@@ -53,4 +53,40 @@ class ElementAnchorTests extends FunctionalTest {
         $this->assertEquals('element-1-3', $recordSet[2]->getAnchor());
         $this->assertEquals('element-1-4', $recordSet[3]->getAnchor());
     }
+
+    /**
+     * Test virtual element Anchor ID.
+     */
+    public function testVirtualElementAnchor() {
+        Config::inst()->update('BaseElement', 'enable_title_in_template', true);
+
+        $baseElement1 = BaseElement::create(array('Title' => 'Element 1', 'Sort' => 1));
+        $baseElement1->write();
+        $baseElement2 = BaseElement::create(array('Title' => 'Element 1', 'Sort' => 2));
+        $baseElement2->write();
+        $baseElement3 = BaseElement::create(array('Title' => 'Element 1', 'Sort' => 3));
+        $baseElement3->write();
+        $virtElement1 = ElementVirtualLinked::create(array('LinkedElementID' => $baseElement2->ID));
+        $virtElement1->write();
+        $virtElement2 = ElementVirtualLinked::create(array('LinkedElementID' => $baseElement3->ID));
+        $virtElement2->write();
+
+        $area = ElementalArea::create();
+        $area->Widgets()->add($baseElement1);
+        $area->Widgets()->add($virtElement1);
+        $area->Widgets()->add($virtElement2);
+        $area->write();
+
+        $recordSet = $area->Elements()->toArray();
+        foreach ($recordSet as $record) {
+            // NOTE: This puts it into the $_anchor protected variable
+            //       and caches it.
+            $record->getAnchor();
+        }
+
+        $this->assertEquals('element-1-5', $recordSet[0]->getAnchor());
+        $this->assertEquals('element-1-6', $recordSet[1]->getAnchor());
+        $this->assertEquals('element-1-7', $recordSet[2]->getAnchor());
+    }
+
 }

--- a/tests/ElementAnchorTests.php
+++ b/tests/ElementAnchorTests.php
@@ -60,11 +60,11 @@ class ElementAnchorTests extends FunctionalTest {
     public function testVirtualElementAnchor() {
         Config::inst()->update('BaseElement', 'enable_title_in_template', true);
 
-        $baseElement1 = BaseElement::create(array('Title' => 'Element 1', 'Sort' => 1));
+        $baseElement1 = BaseElement::create(array('Title' => 'Element 2', 'Sort' => 1));
         $baseElement1->write();
-        $baseElement2 = BaseElement::create(array('Title' => 'Element 1', 'Sort' => 2));
+        $baseElement2 = BaseElement::create(array('Title' => 'Element 2', 'Sort' => 2));
         $baseElement2->write();
-        $baseElement3 = BaseElement::create(array('Title' => 'Element 1', 'Sort' => 3));
+        $baseElement3 = BaseElement::create(array('Title' => 'Element 2', 'Sort' => 3));
         $baseElement3->write();
         $virtElement1 = ElementVirtualLinked::create(array('LinkedElementID' => $baseElement2->ID));
         $virtElement1->write();
@@ -84,9 +84,9 @@ class ElementAnchorTests extends FunctionalTest {
             $record->getAnchor();
         }
 
-        $this->assertEquals('element-1-5', $recordSet[0]->getAnchor());
-        $this->assertEquals('element-1-6', $recordSet[1]->getAnchor());
-        $this->assertEquals('element-1-7', $recordSet[2]->getAnchor());
+        $this->assertEquals('element-2', $recordSet[0]->getAnchor());
+        $this->assertEquals('element-2-2', $recordSet[1]->getAnchor());
+        $this->assertEquals('element-2-3', $recordSet[2]->getAnchor());
     }
 
 }


### PR DESCRIPTION
The anchor feature is nice and useful for standard elements but wasn't implemented for virtual linked elements.