### PR TITLE
Enable preview in the CMS via the full page output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "require": {
         "silverstripe/cms": "^4.0@dev",
         "symbiote/silverstripe-gridfieldextensions": "3.0.x-dev",
-        "arillo/silverstripe-dataobject-preview": "4.0.x-dev",
         "dnadesign/silverstripe-advanceddropdowns": "^2.0",
         "silverstripe/vendor-plugin": "^1.0"
     },

--- a/src/Extensions/ElementalPageExtension.php
+++ b/src/Extensions/ElementalPageExtension.php
@@ -26,13 +26,13 @@ class ElementalPageExtension extends ElementalAreasExtension
     {
         $controller = Controller::curr();
         $request = $controller->getRequest();
-        if($request->getVar('ElementalPreview') !== null) {
+        if ($request->getVar('ElementalPreview') !== null) {
             $html = HTML4Value::create($tags);
             $xpath = "//meta[@name='x-page-id' or @name='x-cms-edit-link']";
             $removeTags = $html->query($xpath);
             $body = $html->getBody();
-            foreach($removeTags as $tag) {
-              $body->removeChild($tag);
+            foreach ($removeTags as $tag) {
+                $body->removeChild($tag);
             }
             $tags = $html->getContent();
         }

--- a/src/Extensions/ElementalPageExtension.php
+++ b/src/Extensions/ElementalPageExtension.php
@@ -36,6 +36,5 @@ class ElementalPageExtension extends ElementalAreasExtension
             }
             $tags = $html->getContent();
         }
-        return $tags;
     }
 }

--- a/src/Extensions/ElementalPageExtension.php
+++ b/src/Extensions/ElementalPageExtension.php
@@ -3,6 +3,8 @@
 namespace DNADesign\Elemental\Extensions;
 
 use DNADesign\Elemental\Models\ElementalArea;
+use SilverStripe\View\Parsers\HTML4Value;
+use SilverStripe\Control\Controller;
 
 class ElementalPageExtension extends ElementalAreasExtension
 {
@@ -19,4 +21,21 @@ class ElementalPageExtension extends ElementalAreasExtension
     private static $owns = [
         'ElementalArea'
     ];
+
+    public function MetaTags(&$tags)
+    {
+        $controller = Controller::curr();
+        $request = $controller->getRequest();
+        if($request->getVar('ElementalPreview') !== null) {
+            $html = HTML4Value::create($tags);
+            $xpath = "//meta[@name='x-page-id' or @name='x-cms-edit-link']";
+            $removeTags = $html->query($xpath);
+            $body = $html->getBody();
+            foreach($removeTags as $tag) {
+              $body->removeChild($tag);
+            }
+            $tags = $html->getContent();
+        }
+        return $tags;
+    }
 }

--- a/src/Extensions/GridFieldDetailFormItemRequestExtension.php
+++ b/src/Extensions/GridFieldDetailFormItemRequestExtension.php
@@ -30,8 +30,7 @@ class GridFieldDetailFormItemRequestExtension extends Extension
     public function updateItemEditForm($form)
     {
         $fields = $form->Fields();
-        if (
-            $this->owner->record instanceof CMSPreviewable &&
+        if ($this->owner->record instanceof CMSPreviewable &&
             !$fields->fieldByName('SilverStripeNavigator')
         ) {
             $template = Controller::curr()
@@ -45,7 +44,7 @@ class GridFieldDetailFormItemRequestExtension extends Extension
             $form->addExtraClass('cms-previewable')
                 ->removeExtraClass('cms-panel-padded center');
             Requirements::javascript(
-              'DNADesign/Elemental:javascript/Elemental.Preview.js'
+                'DNADesign/Elemental:javascript/Elemental.Preview.js'
             );
         }
         return $form;

--- a/src/Extensions/GridFieldDetailFormItemRequestExtension.php
+++ b/src/Extensions/GridFieldDetailFormItemRequestExtension.php
@@ -4,6 +4,10 @@ namespace DNADesign\Elemental\Extensions;
 
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Core\Extension;
+use SilverStripe\Control\Controller;
+use SilverStripe\ORM\CMSPreviewable;
+use SilverStripe\CMS\Controllers\SilverStripeNavigator;
+use SilverStripe\Forms\LiteralField;
 use DNADesign\Elemental\Models\BaseElement;
 
 class GridFieldDetailFormItemRequestExtension extends Extension
@@ -21,5 +25,29 @@ class GridFieldDetailFormItemRequestExtension extends Extension
                 $record->getType()
             ));
         }
+    }
+
+    public function updateItemEditForm($form)
+    {
+        $fields = $form->Fields();
+        if (
+            $this->owner->record instanceof CMSPreviewable &&
+            !$fields->fieldByName('SilverStripeNavigator')
+        ) {
+            $template = Controller::curr()
+                ->getTemplatesWithSuffix('_SilverStripeNavigator');
+            $navigator = SilverStripeNavigator::create($this->owner->record);
+            $field = LiteralField::create(
+                'SilverStripeNavigator',
+                $navigator->renderWith($template)
+            )->setAllowHTML(true);
+            $fields->push($field);
+            $form->addExtraClass('cms-previewable')
+                ->removeExtraClass('cms-panel-padded center');
+            Requirements::javascript(
+              'DNADesign/Elemental:javascript/Elemental.Preview.js'
+            );
+        }
+        return $form;
     }
 }

--- a/src/Extensions/GridFieldDetailFormItemRequestExtension.php
+++ b/src/Extensions/GridFieldDetailFormItemRequestExtension.php
@@ -27,7 +27,13 @@ class GridFieldDetailFormItemRequestExtension extends Extension
         }
     }
 
-    public function updateItemEditForm($form)
+    /**
+     * Updates the edit form to inject the preview panel controls if needed
+     * i.e. if the class being edited implements CMSPreviewable
+     *
+     * @param SilverStripe\Forms\Form $form to be modified by reference
+     */
+    public function updateItemEditForm(&$form)
     {
         $fields = $form->Fields();
         if ($this->owner->record instanceof CMSPreviewable &&
@@ -43,10 +49,6 @@ class GridFieldDetailFormItemRequestExtension extends Extension
             $fields->push($field);
             $form->addExtraClass('cms-previewable')
                 ->removeExtraClass('cms-panel-padded center');
-            Requirements::javascript(
-                'DNADesign/Elemental:javascript/Elemental.Preview.js'
-            );
         }
-        return $form;
     }
 }

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -442,11 +442,7 @@ class BaseElement extends DataObject implements CMSPreviewable
                 break;
             }
 
-            $namespacelessClassname = $this->stripNamespacing($value);
-
             $templates[] = $value . $suffix;
-            $templates[] = 'elements/' . $namespacelessClassname . $suffix;
-            $templates[] = $namespacelessClassname . $suffix;
         }
 
         return $templates;
@@ -454,11 +450,11 @@ class BaseElement extends DataObject implements CMSPreviewable
 
     /**
      * Strip all namespaces from class namespace
-     * @param string e.g. "\Fully\Namespaced\Class"
+     * @param string $classname e.g. "\Fully\Namespaced\Class"
      *
      * @return string following the param example, "Class"
      */
-    private function stripNamespacing($classname)
+    protected function stripNamespacing($classname)
     {
         $classParts = explode('\\', $classname);
         return array_pop($classParts);


### PR DESCRIPTION
Viewing the content block without it's surrounding
context isn't ideal from a user's perspective.
So we'll instead render the page that the current
content block (element) belongs to, jumping to the
relevant section via an anchor.