### PR TITLE
API Add Title and Displayed input group to base element, rearrange Type and i18n names

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,22 +1,27 @@
 en:
   DNADesign\Elemental\Models\BaseElement:
     ALL: 'All types'
+    BlockType: Block
     ELEMENTTYPE: 'Element Type'
     ExtraCssClassesLabel: 'Custom CSS classes'
     ExtraCssClassesPlaceholder: 'my_class another_class'
-    PLURALNAME: 'Content Elements'
+    MainTabLabel: Content
+    PLURALNAME: blocks
     PLURALS:
-      one: 'A Content Element'
-      other: '{count} Content Elements'
-    SINGULARNAME: 'Content Element'
+      one: 'A block'
+      other: '{count} blocks'
+    SINGULARNAME: block
+    ShowTitleLabel: Displayed
+    TitleLabel: 'Title (not displayed unless specified)'
   DNADesign\Elemental\Models\ElementContent:
+    BlockType: Content
     CONTENT: Content
     CUSTOM_STYLES: 'Select a custom style..'
-    PLURALNAME: 'Content Elements'
+    PLURALNAME: 'content blocks'
     PLURALS:
-      one: 'A Content Element'
-      other: '{count} Content Elements'
-    SINGULARNAME: 'Content Element'
+      one: 'A content block'
+      other: '{count} content blocks'
+    SINGULARNAME: 'content block'
     STYLE: Style
   DNADesign\Elemental\Models\ElementalArea:
     PLURALNAME: 'Elemental Areas'

--- a/src/Forms/ElementalGridFieldAddNewMultiClass.php
+++ b/src/Forms/ElementalGridFieldAddNewMultiClass.php
@@ -20,6 +20,7 @@ class ElementalGridFieldAddNewMultiClass extends GridFieldAddNewMultiClass
     public function getHTMLFragments($grid)
     {
         $classes = $this->getClasses($grid);
+        $classes = $this->applyBlockTypeTitles($classes);
 
         if (!count($classes)) {
             return array();
@@ -53,5 +54,25 @@ class ElementalGridFieldAddNewMultiClass extends GridFieldAddNewMultiClass
         return array(
             $this->getFragment() => $data->renderWith(parent::class)
         );
+    }
+
+    /**
+     * Return a list of classes for use in the "add new" block dropdown, using the block's type rather
+     * than i18n singular name as the title
+     *
+     * @param  array $classes
+     * @return array
+     */
+    public function applyBlockTypeTitles(array $classes)
+    {
+        $output = [];
+
+        foreach ($classes as $sanitisedClassName => $originalTitle) {
+            $className = $this->unsanitiseClassName($sanitisedClassName);
+
+            $output[$sanitisedClassName] = singleton($className)->getType();
+        }
+
+        return $output;
     }
 }

--- a/src/Models/ElementContent.php
+++ b/src/Models/ElementContent.php
@@ -8,38 +8,23 @@ use SilverStripe\ORM\FieldType\DBField;
 
 class ElementContent extends BaseElement
 {
-    /**
-     * @var string
-     */
     private static $icon = 'dnadesign/silverstripe-elemental:images/content.svg';
 
-    /**
-     * @var array
-     */
     private static $db = [
         'HTML' => 'HTMLText',
         'Style' => 'Varchar(255)'
     ];
 
-    /**
-     * @var string
-     */
     private static $table_name = 'ElementContent';
+
+    private static $singular_name = 'content block';
+
+    private static $plural_name = 'content blocks';
 
     /**
      * @var array
      */
     private static $styles = [];
-
-    /**
-     * @var string
-     */
-    private static $title = 'Content';
-
-    /**
-     * @var string
-     */
-    private static $description = 'HTML block';
 
     /**
      * {@inheritDoc}
@@ -88,5 +73,10 @@ class ElementContent extends BaseElement
     public function ElementSummary()
     {
         return DBField::create_field('HTMLText', $this->HTML)->Summary(20);
+    }
+
+    public function getType()
+    {
+        return _t(__CLASS__ . '.BlockType', 'Content');
     }
 }

--- a/templates/DNADesign/Elemental/Models/BaseElement/FieldGroup.ss
+++ b/templates/DNADesign/Elemental/Models/BaseElement/FieldGroup.ss
@@ -1,0 +1,7 @@
+<%-- Displays two fields in a Bootstrap input group - used for Title and Displayed --%>
+<div class="input-group">
+    $FieldList.first
+    <span class="input-group-addon pl-4">
+        $FieldList.last $FieldList.last.Title
+    </span>
+</div>

--- a/templates/DNADesign/Elemental/Models/ElementContent.ss
+++ b/templates/DNADesign/Elemental/Models/ElementContent.ss
@@ -1,3 +1,6 @@
-<div class="elementcontent-content <% if Style %>elementcontent--$CssStyle<% end_if %>">
-	$HTML
+<div class="contentelement__content <% if $Style %>$CssStyle<% end_if %>">
+	<% if $ShowTitle %>
+        <h2 class="contentelement__title">$Title</h2>
+    <% end_if %>
+    $HTML
 </div>

--- a/tests/Forms/ElementalGridFieldAddNewMultiClassTest.php
+++ b/tests/Forms/ElementalGridFieldAddNewMultiClassTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DNADesign\Elemental\Tests\Forms;
+
+use DNADesign\Elemental\Forms\ElementalGridFieldAddNewMultiClass;
+use SilverStripe\Dev\SapphireTest;
+
+class ElementalGridFieldAddNewMultiClassTest extends SapphireTest
+{
+    public function testBlockTypeIsUsedForTitle()
+    {
+        $component = new ElementalGridFieldAddNewMultiClass;
+
+        $result = $component->applyBlockTypeTitles([
+            'DNADesign-Elemental-Models-ElementContent' => 'content block'
+        ]);
+
+        $this->assertSame('Content', $result['DNADesign-Elemental-Models-ElementContent']);
+    }
+}


### PR DESCRIPTION
This pull request does a couple of things:

* Add a Bootstrap input group for Title + Displayed checkbox to the base element:

![image](https://user-images.githubusercontent.com/5170590/31642503-cec9af6a-b347-11e7-97ca-8eeb38094fa3.png)

* Refactor `BaseElement::getCMSFields` to use DataObject's own form scaffolding.
* Remove the configurable title method/options. Now use either the Title defined in the CMS, or fall back to the i18n singular name for the block type.
* Add a "block type" translatable method, which is used for the UI:

![image](https://user-images.githubusercontent.com/5170590/31642523-f1e6a836-b347-11e7-8d37-543111869a7d.png)

* Run text collector to update localisations
* Rename the "Main" tab to "Content" for all blocks
* Rename content element's template class names to BEM convention `[blocktype]element__[element]` where `[blocktype]` is `file`, `content`, etc and `[element]` is the structural element in the template, e.g. `title`, `list`, etc