### PR TITLE
Enable the new MeatballMenu gridfield-extension

### DIFF
--- a/src/ElementalEditor.php
+++ b/src/ElementalEditor.php
@@ -12,11 +12,14 @@ use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridFieldVersionedState;
 use SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
+use SilverStripe\Forms\GridField\GridFieldDetailForm;
+use SilverStripe\Forms\GridField\GridFieldEditButton;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Forms\GridField\GridFieldSortableHeader;
 use SilverStripe\Forms\GridField\GridFieldPageCount;
 use SilverStripe\Core\Injector\Injector;
+use Symbiote\GridFieldExtensions\GridFieldActionsMenu;
 use Symbiote\GridFieldExtensions\GridFieldAddNewMultiClass;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
@@ -116,13 +119,22 @@ class ElementalEditor
                     GridFieldAddNewButton::class,
                     GridFieldSortableHeader::class,
                     GridFieldDeleteAction::class,
+                    GridFieldEditButton::class,
                     GridFieldPaginator::class,
                     GridFieldPageCount::class,
                     GridFieldVersionedState::class,
-                    GridFieldAddExistingAutocompleter::class
+                    GridFieldAddExistingAutocompleter::class,
+                    // Detail form will be added back, but a lower priority order for route processing
+                    // We need MeatballMenu to handle the same routes. Detail form is required by
+                    // \Symbiote\GridFieldExtensions\GridFieldAddNewMultiClass so can't just be removed,
+                    // since it AddNewMultiClass is also utilised by Elemental.
+                    GridFieldDetailForm::class
                 ))
                 ->addComponent(new GridFieldOrderableRows('Sort'))
-                ->addComponent(new GridFieldDeleteAction(true))
+                ->addComponents(
+                    new GridFieldActionsMenu(false),
+                    new GridFieldDetailForm
+                )
         );
 
         $gridField->addExtraClass('elemental-editor');

--- a/src/Extensions/ElementalPageExtension.php
+++ b/src/Extensions/ElementalPageExtension.php
@@ -5,7 +5,6 @@ namespace DNADesign\Elemental\Extensions;
 use DNADesign\Elemental\Models\ElementalArea;
 use SilverStripe\View\Parsers\HTML4Value;
 use SilverStripe\Control\Controller;
-use SilverStripe\Forms\FieldList;
 
 class ElementalPageExtension extends ElementalAreasExtension
 {
@@ -37,26 +36,5 @@ class ElementalPageExtension extends ElementalAreasExtension
             }
             $tags = $html->getContent();
         }
-    }
-
-    public function updateCMSFields(FieldList $fields)
-    {
-        $fields = parent::updateCMSFields($fields);
-        $gf = $fields->dataFieldByName('ElementalArea');
-        $cfg = $gf->getConfig();
-        $cfg->removeComponentsByType([
-            '\SilverStripe\Forms\GridField\GridFieldEditButton',
-            '\SilverStripe\Forms\GridField\GridFieldDeleteAction',
-            // Detail form will be added back, but a lower priority order for route processing
-            // We need MeatballMenu to handle the same routes. Detail form is required by
-            // \Symbiote\GridFieldExtensions\GridFieldAddNewMultiClass so can't just be removed,
-            // since it AddNewMultiClass is also utilised by Elemental.
-            '\SilverStripe\Forms\GridField\GridFieldDetailForm'
-        ]);
-        $cfg->addComponents(
-            new \Symbiote\GridFieldExtensions\GridFieldMeatballMenuComponent,
-            new \SilverStripe\Forms\GridField\GridFieldDetailForm
-        );
-        return $fields;
     }
 }

--- a/src/Extensions/ElementalPageExtension.php
+++ b/src/Extensions/ElementalPageExtension.php
@@ -5,6 +5,7 @@ namespace DNADesign\Elemental\Extensions;
 use DNADesign\Elemental\Models\ElementalArea;
 use SilverStripe\View\Parsers\HTML4Value;
 use SilverStripe\Control\Controller;
+use SilverStripe\Forms\FieldList;
 
 class ElementalPageExtension extends ElementalAreasExtension
 {
@@ -36,5 +37,26 @@ class ElementalPageExtension extends ElementalAreasExtension
             }
             $tags = $html->getContent();
         }
+    }
+
+    public function updateCMSFields(FieldList $fields)
+    {
+        $fields = parent::updateCMSFields($fields);
+        $gf = $fields->dataFieldByName('ElementalArea');
+        $cfg = $gf->getConfig();
+        $cfg->removeComponentsByType([
+            '\SilverStripe\Forms\GridField\GridFieldEditButton',
+            '\SilverStripe\Forms\GridField\GridFieldDeleteAction',
+            // Detail form will be added back, but a lower priority order for route processing
+            // We need MeatballMenu to handle the same routes. Detail form is required by
+            // \Symbiote\GridFieldExtensions\GridFieldAddNewMultiClass so can't just be removed,
+            // since it AddNewMultiClass is also utilised by Elemental.
+            '\SilverStripe\Forms\GridField\GridFieldDetailForm'
+        ]);
+        $cfg->addComponents(
+            new \Symbiote\GridFieldExtensions\GridFieldMeatballMenuComponent,
+            new \SilverStripe\Forms\GridField\GridFieldDetailForm
+        );
+        return $fields;
     }
 }


### PR DESCRIPTION
As per design updates for the SilverStripe 4 release
each row now has actions on it that allow for things
such as publication to be enacted without the need to
browse deeper into the GridField item view; UX++

---
Depends on:
- [ ] https://github.com/symbiote/silverstripe-gridfieldextensions/pull/225