### PR TITLE
"Discarded changes" message is no longer displayed onCreate()

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -15,3 +15,7 @@ SilverStripe\CMS\Controllers\ContentController:
 SilverStripe\Versioned\VersionedGridFieldItemRequest:
   extensions:
     - 'DNADesign\Elemental\Extensions\GridFieldDetailFormItemRequestExtension'
+
+Symbiote\GridFieldExtensions\GridFieldAddNewMultiClassHandler:
+  extensions:
+    - DNADesign\Elemental\Extensions\GridFieldAddNewMultiClassHandlerExtension

--- a/src/Extensions/GridFieldAddNewMultiClassHandlerExtension.php
+++ b/src/Extensions/GridFieldAddNewMultiClassHandlerExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DNADesign\Elemental\Extensions;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\Form;
+use DNADesign\Elemental\Models\BaseElement;
+
+/**
+ * Class GridFieldAddNewMultiClassHandlerExtension
+ * @package DNADesign\Elemental\Extensions
+ */
+class GridFieldAddNewMultiClassHandlerExtension extends Extension
+{
+    /**
+     * @param Form $form
+     */
+    public function updateItemEditForm(Form $form)
+    {
+        // NOTE: this extension is applied to new item edit form only
+
+        $record = $form->getRecord();
+        if ($record instanceof BaseElement) {
+            // prevent lost changes popup message when creating a new element
+            $form->addExtraClass('discardchanges');
+        }
+    }
+}


### PR DESCRIPTION
Discarded changes popup message no longer shows up when creating a new element.

Related to:

https://github.com/dnadesign/silverstripe-elemental/issues/142