### PR TITLE
fix(ElementList): Provide a better error message

### DIFF
--- a/code/models/ElementList.php
+++ b/code/models/ElementList.php
@@ -105,6 +105,9 @@ class ElementList extends BaseElement
                 $sorted = array();
 
                 foreach ($list as $class) {
+                    if (!class_exists($class)) {
+                        throw new Exception($class.' is defined in '.get_class($this).'::allowed_elements config but doesn\'t exist.');
+                    }
                     $inst = singleton($class);
 
                     if ($inst->canCreate()) {

--- a/code/models/ElementList.php
+++ b/code/models/ElementList.php
@@ -106,7 +106,7 @@ class ElementList extends BaseElement
 
                 foreach ($list as $class) {
                     if (!class_exists($class)) {
-                        throw new Exception($class.' is defined in '.get_class($this).'::allowed_elements config but doesn\'t exist.');
+                        user_error($class.' is defined in '.get_class($this).'::allowed_elements config but doesn\'t exist.', E_USER_WARNING);
                     }
                     $inst = singleton($class);
 


### PR DESCRIPTION
**WARNING: This is against branch `1`**

fix(ElementList): Provide a better error message when a class doesn't exist that's defined against an ElementList or ElementList subclass.
