### PR TITLE
FIX Ensure instance has the method before calling it

### DIFF
--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -136,7 +136,11 @@ class ElementalArea extends DataObject
     {
         if ($this->OwnerClassName) {
             $class = $this->OwnerClassName;
-            $elementalAreaRelations = Injector::inst()->get($class)->getElementalRelations();
+            $instance = Injector::inst()->get($class);
+            if (!ClassInfo::hasMethod($instance, 'getElementalRelations')) {
+                return;
+            }
+            $elementalAreaRelations = $instance->getElementalRelations();
 
             foreach ($elementalAreaRelations as $eaRelationship) {
                 $areaID = $eaRelationship . 'ID';
@@ -150,7 +154,11 @@ class ElementalArea extends DataObject
         }
 
         foreach ($this->supportedPageTypes() as $class) {
-            $elementalAreaRelations = Injector::inst()->get($class)->getElementalRelations();
+            $instance = Injector::inst()->get($class);
+            if (!ClassInfo::hasMethod($instance, 'getElementalRelations')) {
+                return;
+            }
+            $elementalAreaRelations = $instance->getElementalRelations();
 
             foreach ($elementalAreaRelations as $eaRelationship) {
                 $areaID = $eaRelationship . 'ID';


### PR DESCRIPTION
This fixes a situation where the elemental reports will throw exceptions in the Reports area when the elemental page extension is not applied to the page.