### PR TITLE
Extension point added to CMSEditLink preview.

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -590,10 +590,14 @@ class BaseElement extends DataObject implements CMSPreviewable
             $this->ID
         );
 
-        return Controller::join_links(
+        $link = Controller::join_links(
             $link,
             'edit'
         );
+
+        $this->extend('updateCMSEditLink', $link);
+
+        return $link;
     }
 
     /**


### PR DESCRIPTION
* added an extension point to `CMSEditLink()`
* this is needed for https://github.com/dnadesign/silverstripe-elemental-list/pull/6