### PR TITLE
FIX Remove admin edit button from element holder to prevent canEdit errors

### DIFF
--- a/templates/ElementHolder.ss
+++ b/templates/ElementHolder.ss
@@ -1,11 +1,3 @@
 <div class="element $SimpleClassName.LowerCase<% if $StyleVariant %> $StyleVariant<% end_if %><% if $ExtraClass %> $ExtraClass<% end_if %>" id="$Anchor">
-	<% uncached %>
-		<% if canEdit && isCMSPreview == 0 %>
-			<div style="position: relative">
-				<a href="$CMSEditLink" style="position: absolute; right: 0; top: 0; padding: 5px 10px; background: #0071c4; color: white;">Edit</a>
-			</div>
-		<% end_if %>
-	<% end_uncached %>
-
 	$Element
 </div>


### PR DESCRIPTION
Initially when I load a page with blocks on it I get the following error:

```
[Warning] Missing argument 1 for SilverStripe\ORM\DataExtension::canEdit()
GET /blocks-page/
Line 91 in /Users/robbieaverill/dev/ss4/vendor/silverstripe/framework/src/ORM/DataExtension.php
```

This comes from the `canView` call with no arguments in this template.

The purpose of this code appears to be to add a button to edit the element in the CMS, while viewing it on the frontend and logged in as an admin.

I don't think this change was/is desirable, so I've removed it since it's not working.

cc @clarkepaul @pitchandtone 