### PR TITLE
Pulls/2/elemental area publish permissions

### DIFF
--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -13,6 +13,7 @@ use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\ORM\UnsavedRelationList;
+use SilverStripe\Security\Permission;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\Requirements;
 use SilverStripe\View\SSViewer;
@@ -174,5 +175,21 @@ class ElementalArea extends DataObject
         }
 
         return false;
+    }
+
+    public function canEdit($member = null)
+    {
+        if (Permission::check('ADMIN')) {
+            return true;
+        }
+        return $this->getOwnerPage()->canEdit($member);
+    }
+
+    public function canView($member = null)
+    {
+        if (Permission::check('ADMIN')) {
+            return true;
+        }
+        return $this->getOwnerPage()->canView($member);
     }
 }

--- a/tests/ElementalAreaTest.php
+++ b/tests/ElementalAreaTest.php
@@ -4,13 +4,10 @@ namespace DNADesign\Elemental\Tests;
 
 use DNADesign\Elemental\Extensions\ElementalPageExtension;
 use DNADesign\Elemental\Models\ElementalArea;
-use DNADesign\Elemental\Models\ElementContent;
-use DNADesign\Elemental\Forms\ElementalGridFieldAddNewMultiClass;
 use DNADesign\Elemental\Tests\Src\TestElement;
+use DNADesign\Elemental\Tests\Src\TestPage;
 use Page;
-use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Forms\GridField\GridField;
 
 class ElementalAreaTest extends SapphireTest
 {
@@ -23,7 +20,8 @@ class ElementalAreaTest extends SapphireTest
     ];
 
     protected static $extra_dataobjects = [
-        TestElement::class
+        TestElement::class,
+        TestPage::class,
     ];
 
     public function testElementControllers()
@@ -45,5 +43,19 @@ class ElementalAreaTest extends SapphireTest
 
         $this->assertContains('Hello Test', $area->forTemplate());
         $this->assertContains('Hello Test 2', $area->forTemplate());
+    }
+
+    public function testCanBePublished()
+    {
+        $member = $this->logInWithPermission('SITETREE_EDIT_ALL');
+
+        $page = $this->objFromFixture(TestPage::class, 'page1');
+        $this->assertTrue($page->canPublish($member));
+
+        $area = $this->objFromFixture(ElementalArea::class, 'area1');
+        $this->assertTrue($area->canPublish($member));
+
+        $element = $this->objFromFixture(TestElement::class, 'element1');
+        $this->assertTrue($element->canPublish($member));
     }
 }


### PR DESCRIPTION
Simple check of the parent page to determine whether the area can be edited (and thus published).

Considerations:

 - do we want a granular set of permissions for Elements?
 - do we want/need an equivalent `canView()` etc?

Fixes #156 