### PR TITLE
FIX Remove the aliased versioned GridFieldState component

### DIFF
--- a/src/ElementalEditor.php
+++ b/src/ElementalEditor.php
@@ -15,6 +15,7 @@ use SilverStripe\Forms\GridField\GridFieldPageCount;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\GridField\GridFieldSortableHeader;
 use SilverStripe\Forms\GridField\GridFieldVersionedState;
+use SilverStripe\Versioned\VersionedGridFieldState\VersionedGridFieldState;
 use Symbiote\GridFieldExtensions\GridFieldAddNewMultiClass;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
@@ -117,6 +118,7 @@ class ElementalEditor
                     GridFieldPaginator::class,
                     GridFieldPageCount::class,
                     GridFieldVersionedState::class,
+                    VersionedGridFieldState::class,
                     GridFieldAddExistingAutocompleter::class,
                 ))
                 ->addComponent(new GridFieldOrderableRows('Sort'))


### PR DESCRIPTION
Between SS 4.0 to 4.1 this component was copied to the versioned module and the original was deprecated. This means that the new component shows up in all GridFields by default again, so this is a patch to remove both the old and new component names.

This change leaves both components in place because we need to support SS 4.0 and 4.1+, so can't just use the new namespace.

Before:
![image](https://user-images.githubusercontent.com/5170590/36081149-0e803b14-1000-11e8-82c5-47cad03f71af.png)


This is only until #165 is completed, since that will actually reintroduce this component in one way or another. For now it's displayed incorrectly so removing it as per the current code logic.

cc @sachajudd