### PR TITLE
NEW Enable elemental content to return its owner page in CMS SiteTree searches

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -19,3 +19,7 @@ SilverStripe\Versioned\VersionedGridFieldItemRequest:
 Symbiote\GridFieldExtensions\GridFieldAddNewMultiClassHandler:
   extensions:
     - DNADesign\Elemental\Extensions\GridFieldAddNewMultiClassHandlerExtension
+
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\CMS\Controllers\CMSSiteTreeFilter_Search:
+    class: DNADesign\Elemental\Controllers\ElementSiteTreeFilterSearch

--- a/src/Controllers/ElementSiteTreeFilterSearch.php
+++ b/src/Controllers/ElementSiteTreeFilterSearch.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace DNADesign\Elemental\Controllers;
+
+use DNADesign\Elemental\Extensions\ElementalPageExtension;
+use SilverStripe\CMS\Controllers\CMSSiteTreeFilter_Search;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Forms\DateField;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataList;
+
+class ElementSiteTreeFilterSearch extends CMSSiteTreeFilter_Search
+{
+    /**
+     * @var array
+     */
+    private $extraTermFilters = [];
+
+    /**
+     * We can't use ORM filtering for PHP methods, so we'll perform our own PHP "search" and get a list of
+     * matching SiteTree record IDs, then add that to the original ORM query.
+     *
+     * @param DataList $query Unfiltered query
+     * @return DataList
+     */
+    protected function applyDefaultFilters($query)
+    {
+        // If not filtering by a Term then skip this altogether
+        if (empty($this->params['Term'])) {
+            return parent::applyDefaultFilters($query);
+        }
+
+        // Get an array of SiteTree record IDs that match the search term in nested element data
+        /** @var ArrayList $siteTrees */
+        $siteTrees = $query->filterByCallback(function (SiteTree $siteTree) {
+            // Filter by elemental PHP
+            if (!$siteTree->hasExtension(ElementalPageExtension::class)) {
+                return false;
+            }
+
+            // Check whether the search term exists in the nested page content
+            $pageContent = $siteTree->getElementsForSearch();
+            return (bool) stripos($pageContent, $this->params['Term']) !== false;
+        });
+
+        if ($siteTrees->count()) {
+            // Apply the list of IDs as an extra filter
+            $this->extraTermFilters['ID:ExactMatch'] = $siteTrees->column('ID');
+        }
+
+        return $this->applyWithExtraTermFilters($query);
+    }
+
+    /**
+     * Method is a copy of {@link CMSSiteTreeFilter::applyDefaultFilters} with one line added to the Term
+     * filter array to merge in a custom array of "extra term filters", since we cannot modify the list
+     * after the filters have been applied by the parent class.
+     *
+     * PLEASE NOTE: This method is likely to be removed in a future minor version of the module. Do not rely
+     * on it.
+     *
+     * @internal
+     *
+     * @param DataList $query
+     * @return DataList
+     */
+    private function applyWithExtraTermFilters($query)
+    {
+        $sng = SiteTree::singleton();
+        foreach ($this->params as $name => $val) {
+            if (empty($val)) {
+                continue;
+            }
+
+            switch ($name) {
+                case 'Term':
+                    $query = $query->filterAny([
+                        'URLSegment:PartialMatch' => $val,
+                        'Title:PartialMatch' => $val,
+                        'MenuTitle:PartialMatch' => $val,
+                        'Content:PartialMatch' => $val
+                        ] + $this->extraTermFilters); // NB: only modified line
+                    break;
+
+                case 'LastEditedFrom':
+                    $fromDate = DateField::create(null, null, $val);
+                    $query = $query->filter("LastEdited:GreaterThanOrEqual", $fromDate->dataValue().' 00:00:00');
+                    break;
+
+                case 'LastEditedTo':
+                    $toDate = DateField::create(null, null, $val);
+                    $query = $query->filter("LastEdited:LessThanOrEqual", $toDate->dataValue().' 23:59:59');
+                    break;
+
+                case 'ClassName':
+                    if ($val != 'All') {
+                        $query = $query->filter('ClassName', $val);
+                    }
+                    break;
+
+                default:
+                    $field = $sng->dbObject($name);
+                    if ($field) {
+                        $filter = $field->defaultSearchFilter();
+                        $filter->setValue($val);
+                        $query = $query->alterDataQuery([$filter, 'apply']);
+                    }
+            }
+        }
+        return $query;
+    }
+}

--- a/tests/Controllers/ElementSiteTreeFilterSearchTest.php
+++ b/tests/Controllers/ElementSiteTreeFilterSearchTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace DNADesign\Elemental\Tests\Controllers;
+
+use DNADesign\Elemental\Extensions\ElementalPageExtension;
+use DNADesign\Elemental\Tests\Src\TestPage;
+use Page;
+use SilverStripe\CMS\Controllers\CMSSiteTreeFilter_Search;
+use SilverStripe\Dev\SapphireTest;
+
+class ElementSiteTreeFilterSearchTest extends SapphireTest
+{
+    protected static $fixture_file = 'ElementSiteTreeFilterSearchTest.yml';
+
+    protected static $extra_dataobjects = [
+        TestPage::class,
+    ];
+
+    /**
+     * @param string $searchTerm
+     * @param array $expected
+     * @dataProvider searchProvider
+     */
+    public function testElementalPageDataMatchesInCmsSearch($searchTerm, $expected)
+    {
+        $filter = CMSSiteTreeFilter_Search::create(['Term' => $searchTerm]);
+        $result = $filter->getFilteredPages();
+
+        $this->assertListContains($expected, $result);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function searchProvider()
+    {
+        return [
+            'Nested block data' => ['specifically', [
+                ['Title' => 'Content blocks page'],
+            ]],
+            'Regular page data' => ['regular', [
+                ['Title' => 'Regular page'],
+            ]],
+            'Combined results' => ['content', [
+                ['Title' => 'Content blocks page'],
+                ['Title' => 'Regular page'],
+            ]],
+        ];
+    }
+}

--- a/tests/Controllers/ElementSiteTreeFilterSearchTest.yml
+++ b/tests/Controllers/ElementSiteTreeFilterSearchTest.yml
@@ -1,0 +1,19 @@
+DNADesign\Elemental\Models\ElementalArea:
+  blocks_page_area:
+    Title: Area 1
+
+DNADesign\Elemental\Tests\Src\TestPage:
+  blocks_page:
+    Title: Content blocks page
+    URLSegment: blocks-page
+    ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.blocks_page_area
+  regular_page:
+    Title: Regular page
+    URLSegment: regular-page
+    Content: Some normal page content
+
+DNADesign\Elemental\Models\ElementContent:
+  blocks_page_content:
+    Title: Content
+    HTML: Specifically blocks page content
+    ParentID: =>DNADesign\Elemental\Models\ElementalArea.blocks_page_area

--- a/tests/Src/TestPage.php
+++ b/tests/Src/TestPage.php
@@ -2,17 +2,15 @@
 
 namespace DNADesign\Elemental\Tests\Src;
 
-use Page;
 use DNADesign\Elemental\Extensions\ElementalPageExtension;
-use DNADesign\Elemental\Models\ElementalArea;
+use Page;
 use SilverStripe\Dev\TestOnly;
-use SilverStripe\View\SSViewer;
 
 class TestPage extends Page implements TestOnly
 {
     private static $table_name = 'TestElementalPage';
 
-    private static $extensions = array(
+    private static $extensions = [
         ElementalPageExtension::class
-    );
+    ];
 }


### PR DESCRIPTION
Please note that this logic will not be performant in larger data sets, and is likely to change in future in favour of a more rigid and specific set of ORM joins.

I've marked the method which will definitely be removed once this enhancement is made as `@internal` with a warning not to use it, and have made it private just to make sure.

Better way to do this will be logged as a 2.1.x enhancement separately.

Resolves #163