### PR TITLE
Set getType to use singular name by default

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -6,7 +6,6 @@ en:
     REVERT: 'Revert to this version'
   DNADesign\Elemental\Models\BaseElement:
     Author: Author
-    BlockType: Block
     CUSTOM_STYLES: 'Select a style..'
     ExtraCssClassesLabel: 'Custom CSS classes'
     ExtraCssClassesPlaceholder: 'my_class another_class'

--- a/lang/fr.yml
+++ b/lang/fr.yml
@@ -6,7 +6,6 @@ fr:
     REVERT: 'Revenir à cette version'
   DNADesign\Elemental\Models\BaseElement:
     Author: Auteur
-    BlockType: Bloc
     CUSTOM_STYLES: 'Sélectionner un style..'
     ExtraCssClassesLabel: 'Classes CSS personnalisées'
     ExtraCssClassesPlaceholder: 'ma_classe autre_classe'

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -105,9 +105,9 @@ class BaseElement extends DataObject implements CMSPreviewable
 
     private static $default_sort = 'Sort';
 
-    private static $singular_name = 'block';
+    private static $singular_name = 'Block';
 
-    private static $plural_name = 'blocks';
+    private static $plural_name = 'Blocks';
 
     private static $summary_fields = [
         'EditorPreview' => 'Summary'
@@ -376,7 +376,7 @@ class BaseElement extends DataObject implements CMSPreviewable
      */
     public function getType()
     {
-        return _t(__CLASS__ . '.BlockType', 'Block');
+        return _t(__CLASS__ . '.BlockType', $this->i18n_singular_name());
     }
 
     /**


### PR DESCRIPTION
Set getType to use singular name by default so its consistent with silverstripe.
Removed translations so that doesn't override singular name unless explicitly set by extended element subclass.