### PR TITLE
Write owner class only if updated

### DIFF
--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -176,8 +176,10 @@ class ElementalArea extends DataObject
                 $page = Versioned::get_by_stage($class, Versioned::DRAFT)->filter($areaID, $this->ID);
 
                 if ($page && $page->exists()) {
-                    $this->OwnerClassName = $class;
-                    $this->write();
+                    if ($this->OwnerClassName !== $class) {
+                        $this->OwnerClassName = $class;
+                        $this->write();
+                    }
 
                     return $page->first();
                 }


### PR DESCRIPTION
I had an issue where I was unable to republish a page that had been archived and then restored.
There was an infinite loop with `SilverStripe\Assets\AssetControlExtension` and `DNADesign\Elemental\Models\ElementalArea`

Basically, AssetControlExtension calls `CanView`, which calls `getOwnerPage`, which triggers a `write`, which then goes back to `AssetControlExtension`, kicking the circle off again.

Abbreviated call stack is:
- `SilverStripe\ORM\DataObject->write()` 
ElementalArea.php:180
- `DNADesign\Elemental\Models\ElementalArea->getOwnerPage()` 
ElementalArea.php:222
- `DNADesign\Elemental\Models\ElementalArea->canView()` 
AssetControlExtension.php:116
- `SilverStripe\Assets\AssetControlExtension->SilverStripe\Assets\{closure}()` 
Member.php:815
- `SilverStripe\Security\Member::actAs(, Closure)` 
AssetControlExtension.php:119
- `SilverStripe\Assets\AssetControlExtension->getRecordState(DNADesign\Elemental\Models\ElementalArea)`  
AssetControlExtension.php:86
- `SilverStripe\Assets\AssetControlExtension->onBeforeWrite(, , , , , , ) ` 
Extensible.php:472
- `SilverStripe\View\ViewableData->extend(onBeforeWrite, )` 
DataObject.php:1039
- `SilverStripe\ORM\DataObject->onBeforeWrite()` 
DataObject.php:1185
- `SilverStripe\ORM\DataObject->preWrite()`  
DataObject.php:1343
- `SilverStripe\ORM\DataObject->write()` 
ElementalArea.php:180

This pull request only calls write, if a write is actually needed
