### PR TITLE
FIX: check if base class has ElementPageExtension

### DIFF
--- a/code/extensions/ElementPageExtension.php
+++ b/code/extensions/ElementPageExtension.php
@@ -278,6 +278,12 @@ class ElementPageExtension extends DataExtension
      * @return boolean
      */
     public function supportsElemental() {
+        // check extension applied to base class (avoid error on page class change)
+        $base = singleton($this->owner->ClassName);
+        if (!$base->hasExtension($this->class)) {
+            return false;
+        };
+
         if ($this->owner->hasMethod('includeElemental')) {
             $res = $this->owner->includeElemental();
             if ($res !== null) {

--- a/code/extensions/ElementPageExtension.php
+++ b/code/extensions/ElementPageExtension.php
@@ -280,9 +280,9 @@ class ElementPageExtension extends DataExtension
     public function supportsElemental() {
         // check extension applied to base class (avoid error on page class change)
         $base = singleton($this->owner->ClassName);
-        if (!$base->hasExtension($this->class)) {
+        if (!$base->hasExtension(__CLASS__)) {
             return false;
-        };
+        }
 
         if ($this->owner->hasMethod('includeElemental')) {
             $res = $this->owner->includeElemental();


### PR DESCRIPTION
* avoid potential error when changing page class in CMS

See https://github.com/dnadesign/silverstripe-elemental/issues/203 for further details.