### PR TITLE
add ListingHelper to access iterator information like $Pos, $First, $Last and $EvenOdd

### DIFF
--- a/src/Controllers/ElementController.php
+++ b/src/Controllers/ElementController.php
@@ -61,6 +61,19 @@ class ElementController extends Controller
     }
 
     /**
+     * Get iterator information and pass on to element
+     * @return ElementController
+     */
+    public function ListingHelper($Pos = null, $First = null, $Last = null, $EvenOdd = null)
+    {
+        $this->element->Pos = $Pos;
+        $this->element->First = $First;
+        $this->element->Last = $Last;
+        $this->element->EvenOdd = $EvenOdd;
+        return $this;
+    }
+
+    /**
      * @return Element
      */
     public function getElement()

--- a/templates/DNADesign/Elemental/Models/ElementalArea.ss
+++ b/templates/DNADesign/Elemental/Models/ElementalArea.ss
@@ -1,5 +1,5 @@
 <% if $ElementControllers %>
     <% loop $ElementControllers %>
-	   $Me
+	   $ListingHelper($Pos, $First, $Last, $EvenOdd)
     <% end_loop %>
 <% end_if %>


### PR DESCRIPTION
Hi there,

We had been developing a [similar module](https://github.com/arillo/silverstripe-elements) (mainly for SS3) where we had the necessity to access the iterator information, like $Pos, $First, $Last and $EvenOdd when iterating over blocks. This is a simple helper to achieve just this. Let me know if you need anything or you had a different approach in mind.

