### PR TITLE
Add own phpcs ruleset and fix linting issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests/; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
-  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=vendor/silverstripe/framework/phpcs.xml.dist src/ tests/ ; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs src/ tests/ ; fi
 
 after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="SilverStripe">
+    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+
+    <rule ref="PSR2" >
+        <!-- Current exclusions -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName" />
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+    </rule>
+</ruleset>

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -140,14 +140,14 @@ class BaseElement extends DataObject implements CMSPreviewable
      *
      * @var array
      */
-    protected static $_used_anchors = [];
+    protected static $used_anchors = [];
 
     /**
      * For caching 'getAnchor'
      *
      * @var string
      */
-    protected $_anchor = null;
+    protected $anchor = null;
 
     /**
      * Basic permissions, defaults to page perms where possible.
@@ -353,7 +353,8 @@ class BaseElement extends DataObject implements CMSPreviewable
                 'getAuthor.Name' => _t(__CLASS__ . '.Author', 'Author')
             ])
             ->setFieldFormatting([
-                'RecordStatus' => '$VersionedStateNice <span class=\"element-history__date--small\">on $LastEditedNice</span>',
+                'RecordStatus' => '$VersionedStateNice <span class=\"element-history__date--small\">on '
+                    . '$LastEditedNice</span>',
             ]);
 
         $config->removeComponentsByType(GridFieldViewButton::class);
@@ -405,7 +406,9 @@ class BaseElement extends DataObject implements CMSPreviewable
         $controllerClass = self::config()->controller_class;
 
         if (!class_exists($controllerClass)) {
-            throw new Exception('Could not find controller class ' . $controllerClass . ' as defined in ' . static::class);
+            throw new Exception(
+                'Could not find controller class ' . $controllerClass . ' as defined in ' . static::class
+            );
         }
 
         $this->controller = Injector::inst()->create($controllerClass, $this);
@@ -512,8 +515,8 @@ class BaseElement extends DataObject implements CMSPreviewable
      */
     public function getAnchor()
     {
-        if ($this->_anchor !== null) {
-            return $this->_anchor;
+        if ($this->anchor !== null) {
+            return $this->anchor;
         }
 
         $anchorTitle = '';
@@ -537,12 +540,12 @@ class BaseElement extends DataObject implements CMSPreviewable
         // ie. If two elemental blocks have the same title, it'll append '-2', '-3'
         $result = $titleAsURL;
         $count = 1;
-        while (isset(self::$_used_anchors[$result]) && self::$_used_anchors[$result] !== $this->ID) {
+        while (isset(self::$used_anchors[$result]) && self::$used_anchors[$result] !== $this->ID) {
             ++$count;
-            $result = $titleAsURL.'-'.$count;
+            $result = $titleAsURL . '-' . $count;
         }
-        self::$_used_anchors[$result] = $this->ID;
-        return $this->_anchor = $result;
+        self::$used_anchors[$result] = $this->ID;
+        return $this->anchor = $result;
     }
 
     /**
@@ -630,7 +633,10 @@ class BaseElement extends DataObject implements CMSPreviewable
         if (!$page instanceof SiteTree && method_exists($page, 'CMSEditLink')) {
             $editLinkPrefix = Controller::join_links($page->CMSEditLink(), 'ItemEditForm');
         } else {
-            $editLinkPrefix = Controller::join_links(singleton(CMSPageEditController::class)->Link('EditForm'), $page->ID);
+            $editLinkPrefix = Controller::join_links(
+                singleton(CMSPageEditController::class)->Link('EditForm'),
+                $page->ID
+            );
         }
 
         $link = Controller::join_links(

--- a/src/Tasks/MigrateContentToElement.php
+++ b/src/Tasks/MigrateContentToElement.php
@@ -12,7 +12,8 @@ class MigrateContentToElement extends BuildTask
 
     protected $title = 'MigrateContentToElement';
 
-    protected $description = 'When installing Elemental this task converts content in the $Content field to an ElementContent';
+    protected $description = 'When installing Elemental this task converts content in the $Content '
+        . 'field to an ElementContent';
 
     public function run($request)
     {


### PR DESCRIPTION
I'm treating the renaming of the protected properties as semver safe for a patch here, since they're designed to only be used internally anyway.