### PR TITLE
API Fix controller factory extension name and class it extends

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -3,6 +3,6 @@ Name: elementalextensions
 Only:
   moduleexists: silverstripe/versioned-admin
 ---
-SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController:
+SilverStripe\VersionedAdmin\Controllers\HistoryControllerFactory:
   extensions:
-    - DNADesign\Elemental\Extensions\CMSPageHistoryViewerControllerExtension
+    - DNADesign\Elemental\Extensions\HistoryControllerFactoryExtension

--- a/src/Extensions/HistoryControllerFactoryExtension.php
+++ b/src/Extensions/HistoryControllerFactoryExtension.php
@@ -8,7 +8,7 @@ use SilverStripe\Core\Extension;
 /**
  * Instructs the history viewer controller to be enabled for pages that have elemental
  */
-class CMSPageHistoryViewerControllerExtension extends Extension
+class HistoryControllerFactoryExtension extends Extension
 {
     public function updateIsEnabled(SiteTree $page = null)
     {


### PR DESCRIPTION
Follow up on #231. We changed the extension point's source in https://github.com/silverstripe/silverstripe-versioned-admin/pull/18 to a controller factory, but missed updating it in this PR.