### PR TITLE
FIX push element history revert button to bottom of page

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -299,7 +299,8 @@ class BaseElement extends DataObject
                 $historyViewer = HistoryViewerField::create('ElementHistory');
                 $fields->addFieldToTab('Root.History', $historyViewer);
 
-                $fields->fieldByName('Root.History')->addExtraClass('elemental-block__history-tab');
+                $fields->fieldByName('Root.History')
+                    ->addExtraClass('elemental-block__history-tab tab--history-viewer');
             }
         });
 


### PR DESCRIPTION
Previously both the revert button shows immediately under the content,
and the save/publish buttons show at the bottom of the page (in the CMS)
as per the usual actions for an edit form (for which the
HistoryViewerField is added to under a tab of it's own). Clearly
confusing, a work around has [been introduced](https://github.com/silverstripe/silverstripe-versioned-admin/pull/27) to
silverstripe/versioned-admin in order work around this - this commit
enables that functionality which has been made opt-in as the nature of
it being a work-around.

Resolves https://github.com/silverstripe/silverstripe-versioned-admin/issues/22