### PR TITLE
NEW BaseElement implements CMSPreviewable interface

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -17,6 +17,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
@@ -40,7 +41,7 @@ use SilverStripe\View\Requirements;
  *
  * @method ElementalArea Parent()
  */
-class BaseElement extends DataObject
+class BaseElement extends DataObject implements CMSPreviewable
 {
     /**
      * Override this on your custom elements to specify a CSS icon class


### PR DESCRIPTION
While `CMSPreviewable`'s functions were implemented in prior commits, the interface itself was not implemented. 

https://github.com/silverstripe/silverstripe-admin/issues/480 depends on BaseElement doing so.