### PR TITLE
FIX Check canView() permission before rendering BaseElements

### DIFF
--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -108,7 +108,7 @@ class ElementalArea extends DataObject
      */
     public function ElementControllers()
     {
-        $controllers = new ArrayList();
+        $controllers = ArrayList::create();
         $items = $this->Elements()->filterByCallback(function (BaseElement $item) {
             return $item->canView();
         });

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -109,7 +109,9 @@ class ElementalArea extends DataObject
     public function ElementControllers()
     {
         $controllers = new ArrayList();
-        $items = $this->Elements();
+        $items = $this->Elements()->filterByCallback(function (BaseElement $item) {
+            return $item->canView();
+        });
 
         if (!is_null($items)) {
             foreach ($items as $element) {

--- a/tests/ElementControllerTest.php
+++ b/tests/ElementControllerTest.php
@@ -36,6 +36,8 @@ class ElementControllerTest extends FunctionalTest
     public function testForTemplate()
     {
         $element = $this->objFromFixture(TestElement::class, 'element1');
+        // Although we read from Versioned::DRAFT, Versioned will still block draft content view permissions
+        $this->logInWithPermission('ADMIN');
         $controller = new TestElementController($element);
 
         $this->assertContains('Hello Test', $controller->forTemplate());

--- a/tests/ElementalAreaTest.php
+++ b/tests/ElementalAreaTest.php
@@ -33,16 +33,36 @@ class ElementalAreaTest extends SapphireTest
         $this->assertEquals(2, $controllers->count(), 'Should be a controller per element');
     }
 
-
-    public function testViewPermissionsAreChecked()
+    public function testCanViewTestElementIsFalseWhenLoggedInAsCmsEditor()
     {
+        /** @var ElementalArea $area */
         $area = $this->objFromFixture(ElementalArea::class, 'area2');
-        $controllers = $area->ElementControllers();
-        $elements = $area->Elements();
+        // Content editors do not have permission to view the TestElement
+        $this->logInWithPermission('VIEW_DRAFT_CONTENT');
 
-        $this->assertEquals(1, $controllers->count(),
-            'Should be one controller only, since one of the elements is not viewable');
-        $this->assertEquals(2, $elements->count());
+        $controllers = $area->ElementControllers();
+        $this->assertCount(2, $area->Elements(), 'There are two elements in total');
+        $this->assertCount(
+            1,
+            $controllers,
+            'Should be one controller only, since TestElement is not viewable by non-admins'
+        );
+    }
+
+    public function testCanViewTestElementIsTrueForAdmins()
+    {
+        /** @var ElementalArea $area */
+        $area = $this->objFromFixture(ElementalArea::class, 'area2');
+        // Admin users have permission to view the TestElement
+        $this->logInWithPermission('ADMIN');
+
+        $controllers = $area->ElementControllers();
+        $this->assertCount(2, $area->Elements(), 'There are two elements in total');
+        $this->assertCount(
+            2,
+            $controllers,
+            'Should be two controllers when logged in as admin'
+        );
     }
 
     public function testGetOwnerPage()

--- a/tests/ElementalAreaTest.php
+++ b/tests/ElementalAreaTest.php
@@ -33,6 +33,18 @@ class ElementalAreaTest extends SapphireTest
         $this->assertEquals(2, $controllers->count(), 'Should be a controller per element');
     }
 
+
+    public function testViewPermissionsAreChecked()
+    {
+        $area = $this->objFromFixture(ElementalArea::class, 'area2');
+        $controllers = $area->ElementControllers();
+        $elements = $area->Elements();
+
+        $this->assertEquals(1, $controllers->count(),
+            'Should be one controller only, since one of the elements is not viewable');
+        $this->assertEquals(2, $elements->count());
+    }
+
     public function testGetOwnerPage()
     {
         $area1 = $this->objFromFixture(ElementalArea::class, 'area1');

--- a/tests/ElementalAreaTest.yml
+++ b/tests/ElementalAreaTest.yml
@@ -20,7 +20,19 @@ DNADesign\Elemental\Tests\Src\TestElement:
     Title: Element 1
     TestValue: 'Hello Test'
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.area1
+    Viewable: true
   element2:
     Title: Element 2
     TestValue: 'Hello Test 2'
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.area1
+    Viewable: true
+  element3:
+    Title: Element 3
+    TestValue: 'Hello Test 3'
+    ParentID: =>DNADesign\Elemental\Models\ElementalArea.area2
+    Viewable: true
+  element4:
+    Title: Element 4
+    TestValue: 'Hello Test 4'
+    ParentID: =>DNADesign\Elemental\Models\ElementalArea.area2
+    Viewable: false

--- a/tests/ElementalAreaTest.yml
+++ b/tests/ElementalAreaTest.yml
@@ -20,19 +20,16 @@ DNADesign\Elemental\Tests\Src\TestElement:
     Title: Element 1
     TestValue: 'Hello Test'
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.area1
-    Viewable: true
   element2:
     Title: Element 2
     TestValue: 'Hello Test 2'
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.area1
-    Viewable: true
   element3:
     Title: Element 3
     TestValue: 'Hello Test 3'
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.area2
-    Viewable: true
-  element4:
-    Title: Element 4
-    TestValue: 'Hello Test 4'
+
+DNADesign\Elemental\Models\ElementContent:
+  content1:
+    HTML: Some content
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.area2
-    Viewable: false

--- a/tests/Src/TestElement.php
+++ b/tests/Src/TestElement.php
@@ -2,8 +2,9 @@
 
 namespace DNADesign\Elemental\Tests\Src;
 
-use SilverStripe\Dev\TestOnly;
 use DNADesign\Elemental\Models\BaseElement;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Security\Permission;
 
 class TestElement extends BaseElement implements TestOnly
 {
@@ -11,7 +12,6 @@ class TestElement extends BaseElement implements TestOnly
 
     private static $db = [
         'TestValue' => 'Text',
-        'Viewable' => 'Boolean'
     ];
 
     private static $controller_class = TestElementController::class;
@@ -23,6 +23,10 @@ class TestElement extends BaseElement implements TestOnly
 
     public function canView($member = null)
     {
-        return parent::canView($member) && $this->Viewable;
+        $check = Permission::checkMember($member, 'ADMIN');
+        if ($check !== null) {
+            return $check;
+        }
+        return parent::canView($member);
     }
 }

--- a/tests/Src/TestElement.php
+++ b/tests/Src/TestElement.php
@@ -10,7 +10,8 @@ class TestElement extends BaseElement implements TestOnly
     private static $table_name = 'TestElement';
 
     private static $db = [
-        'TestValue' => 'Text'
+        'TestValue' => 'Text',
+        'Viewable' => 'Boolean'
     ];
 
     private static $controller_class = TestElementController::class;
@@ -18,5 +19,10 @@ class TestElement extends BaseElement implements TestOnly
     public function getType()
     {
         return 'A test element';
+    }
+
+    public function canView($member = null)
+    {
+        return parent::canView($member) && $this->Viewable;
     }
 }


### PR DESCRIPTION
Fixes #253 by checking canView() permissions before rendering BaseElements.

