### PR TITLE
FIX Do not try and filter unsaved lists when determining canView permissions

### DIFF
--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -12,6 +12,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\HasManyList;
+use SilverStripe\ORM\UnsavedRelationList;
 use SilverStripe\Versioned\Versioned;
 
 /**
@@ -108,6 +109,11 @@ class ElementalArea extends DataObject
      */
     public function ElementControllers()
     {
+        // Don't try and process unsaved lists
+        if ($this->Elements() instanceof UnsavedRelationList) {
+            return ArrayList::create();
+        }
+
         $controllers = ArrayList::create();
         $items = $this->Elements()->filterByCallback(function (BaseElement $item) {
             return $item->canView();

--- a/tests/ElementalAreaTest.php
+++ b/tests/ElementalAreaTest.php
@@ -4,10 +4,12 @@ namespace DNADesign\Elemental\Tests;
 
 use DNADesign\Elemental\Extensions\ElementalPageExtension;
 use DNADesign\Elemental\Models\ElementalArea;
+use DNADesign\Elemental\Models\ElementContent;
 use DNADesign\Elemental\Tests\Src\TestElement;
 use DNADesign\Elemental\Tests\Src\TestPage;
 use Page;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\Versioned\Versioned;
 
 class ElementalAreaTest extends SapphireTest
@@ -115,5 +117,19 @@ class ElementalAreaTest extends SapphireTest
         $duplicatedAreaIds = $duplicatedArea->Elements()->column('ID');
         $this->assertCount(2, $duplicatedAreaIds);
         $this->assertNotEquals($areaIds, $duplicatedAreaIds);
+    }
+
+    public function testUnsavedRelationListOfElementsReturnsEmptyArrayList()
+    {
+        $area = new ElementalArea();
+
+        $element = new ElementContent();
+        $element->HTML = 'Test';
+
+        $area->Elements()->add($element);
+
+        $result = $area->ElementControllers();
+        $this->assertInstanceOf(ArrayList::class, $result);
+        $this->assertEmpty($result);
     }
 }


### PR DESCRIPTION
Follow up from #259, fixes #264