### PR TITLE
NEW Add GraphQL query HOC for returning the content blocks on a page

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{yml,scss,js,feature}]
+[*.{yml,scss,js,feature,json}]
 indent_size = 2
 
 # The indent size used in the package.json file cannot be changed:

--- a/_config/graphql.yml
+++ b/_config/graphql.yml
@@ -5,14 +5,31 @@ SilverStripe\GraphQL\Controller:
   schema:
     scaffolding:
       types:
+        # Expose common static fields for the ElementEditor component to use for preview summaries
         DNADesign\Elemental\Models\BaseElement:
-          fields: [ID, LastEdited, AbsoluteLink]
+          fields: [ID, LastEdited, AbsoluteLink, Title, ShowTitle, Sort, Summary]
           operations:
             copyToStage: true
             readOne: true
+        # Expose access to Elements via Page -> ElementalArea -> Elements (see resolver)
+        DNADesign\Elemental\Models\ElementalArea:
+          fields: [ID]
+          nestedQueries:
+            Elements:
+              resolver: DNADesign\Elemental\GraphQL\ElementsResolver
+          operations:
+            readOne: true
+        # Expose ElementalAreas
+        SilverStripe\CMS\Model\SiteTree:
+          fields: [ID, ElementalArea]
+          operations:
+            readOne: true
+        # Basic member information is required for history views
         SilverStripe\Security\Member:
           fields: [ID, FirstName, Surname]
           operations:
             readOne: true
+    # Define specific names for the models we expose
     typeNames:
       DNADesign\Elemental\Models\BaseElement: Block
+      DNADesign\Elemental\Models\ElementalArea: ElementalArea

--- a/client/src/state/editor/readBlocksForPageQuery.js
+++ b/client/src/state/editor/readBlocksForPageQuery.js
@@ -1,0 +1,63 @@
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+
+// GraphQL query for retrieving the current state of elements for a page, via the
+// ElementalArea. The results of the query must be set to the "blocks" prop on
+// the component that this HOC is applied to for binding implementation.
+const query = gql`
+query readBlocksForPage($id:ID!) {
+  readOnePage(ID: $id, Versioning: {
+    Mode: LATEST
+  }){
+    ID
+    ElementalArea {
+      Elements {
+        pageInfo {
+          totalCount
+        }
+        edges {
+          node {
+            ID
+            Title
+            Summary
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+const config = {
+  options({ pageId }) {
+    return {
+      variables: {
+        id: pageId,
+      }
+    };
+  },
+  props(
+    {
+      data: {
+        error,
+        readBlocksForPage,
+        loading: networkLoading,
+      },
+    }
+  ) {
+    const blocks = readBlocksForPage || null;
+
+    const errors = error && error.graphQLErrors &&
+      error.graphQLErrors.map((graphQLError) => graphQLError.message);
+
+    return {
+      loading: networkLoading || !blocks,
+      blocks,
+      graphQLErrors: errors,
+    };
+  },
+};
+
+export { query, config };
+
+export default graphql(query, config);

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.3.0",
+    "graphql-tag": "^0.1.17",
     "jest-cli": "^19.0.2",
+    "react-apollo": "^0.7.1",
     "webpack": "^2.6.1"
   },
   "jest": {

--- a/src/GraphQL/ElementsResolver.php
+++ b/src/GraphQL/ElementsResolver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DNADesign\Elemental\GraphQL;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use SilverStripe\GraphQL\OperationResolver;
+use SilverStripe\ORM\DataList;
+
+class ElementsResolver implements OperationResolver
+{
+    public function resolve($object, array $args, $context, ResolveInfo $info)
+    {
+        if (!$object::singleton()->canView($context['currentUser'])) {
+            throw new \Exception('Current user cannot view elements');
+        }
+
+        /** @var DataList $elements */
+        $elements = $object->Elements();
+        return $elements;
+    }
+}


### PR DESCRIPTION
This will return content blocks via the ElementalArea has_one relationship on a page.
If you have implemented custom or extra has_one ElementalArea relationships then you
will need to replace and/or augment this query using the JavaScript Injector API.

Part of the React elemental editor work: https://github.com/dnadesign/silverstripe-elemental/issues/272