### PR TITLE
FIX Return empty ElementalArea if none exists for the page

### DIFF
--- a/src/Extensions/SiteTreeExtension.php
+++ b/src/Extensions/SiteTreeExtension.php
@@ -12,14 +12,15 @@ use SilverStripe\ORM\DataExtension;
 class SiteTreeExtension extends DataExtension
 {
     /**
-     * Returns the owner's `ElementalArea()` contents if it has the extension
+     * Returns the owner's `ElementalArea()` contents if it has the extension, or an empty one
      *
-     * @return ElementalArea|null
+     * @return ElementalArea
      */
     public function ElementalAreaIfExists()
     {
         if ($this->owner->hasExtension(ElementalPageExtension::class)) {
             return $this->owner->ElementalArea();
         }
+        return ElementalArea::create();
     }
 }


### PR DESCRIPTION
This fixes a bug where no elemental area exists and we get error: "Field \"ElementalAreaIfExists\" of type \"String\" must not have a sub selection."

Issue: #272