### PR TITLE
[Add] Viewer Groups on BaseElement

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -15,11 +15,18 @@ use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\ListboxField;
 use SilverStripe\Forms\NumericField;
+use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\TextField;
+use SilverStripe\Forms\TreeMultiselectField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
+use SilverStripe\Security\Security;
+use SilverStripe\Security\Group;
+use SilverStripe\Security\InheritedPermissions;
+use SilverStripe\Security\InheritedPermissionsExtension;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Versioned\Versioned;
@@ -69,8 +76,13 @@ class BaseElement extends DataObject
         'Parent' => ElementalArea::class
     ];
 
+    private static $many_many = [
+        'ViewerGroups' => Group::class,
+    ];
+
     private static $extensions = [
-        Versioned::class
+        Versioned::class,
+        InheritedPermissionsExtension::class
     ];
 
     private static $versioned_gridfield_extensions = true;
@@ -139,25 +151,57 @@ class BaseElement extends DataObject
     protected $anchor = null;
 
     /**
-     * Basic permissions, defaults to page perms where possible.
+     * This function should return true if the current user can view this element.
+     *
+     * Denies permission if any of the following conditions is true:
+     * - canView() on any extension returns false
+     * - "CanViewType" directive is set to "LoggedInUsers" and no user is logged in
+     * - "CanViewType" directive is set to "OnlyTheseUsers" and user is not in the given groups
+     *
+     * @uses DataExtension->canView()
+     * @uses ViewerGroups()
      *
      * @param Member $member
-     * @return boolean
+     * @return bool True if the current user can view this page
      */
     public function canView($member = null)
     {
-        $extended = $this->extendedCan(__FUNCTION__, $member);
+        if (!$member) {
+            $member = Security::getCurrentUser();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canView', $member);
         if ($extended !== null) {
             return $extended;
         }
 
-        if ($this->hasMethod('getPage')) {
-            if ($page = $this->getPage()) {
-                return $page->canView($member);
-            }
+        // admin override
+        if ($member && Permission::checkMember($member, array("ADMIN", "SITETREE_VIEW_ALL"))) {
+            return true;
         }
 
-        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
+        // Note: getInheritedPermissions() is disused in this instance
+        // to allow parent canView extensions to influence canView()
+
+        // check for empty spec
+        if (!$this->CanViewType || $this->CanViewType === InheritedPermissions::ANYONE) {
+            return true;
+        }
+
+        // check for any logged-in users
+        if ($this->CanViewType === InheritedPermissions::LOGGED_IN_USERS && $member && $member->ID) {
+            return true;
+        }
+
+        // check for specific groups
+        if ($this->CanViewType === InheritedPermissions::ONLY_THESE_USERS
+            && $member
+            && $member->inGroups($this->ViewerGroups())) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -310,6 +354,42 @@ class BaseElement extends DataObject
                 $fields->fieldByName('Root.History')
                     ->addExtraClass('elemental-block__history-tab tab--history-viewer');
             }
+
+            // Viewer groups (remove tabs from silverstripe/asset-admin)
+            $fields->removeByName('ViewerGroups');
+            $fields->removeByName('EditorGroups');
+
+            //group options field
+            $viewersOptionsField = OptionsetField::create(
+                "CanViewType",
+                _t(__class__ . '.ACCESSHEADER', "Who can view this page?")
+            );
+
+            //group options set
+            $viewersOptionsSource = [
+                InheritedPermissions::ANYONE => _t(__class__ . '.ACCESSANYONE', "Anyone"),
+                InheritedPermissions::LOGGED_IN_USERS => _t(__class__ . '.ACCESSLOGGEDIN', "Logged-in users"),
+                InheritedPermissions::ONLY_THESE_USERS => _t(
+                    __class__ . '.ACCESSONLYTHESE',
+                    "Only these groups (choose from list)"
+                ),
+            ];
+
+            //attach set to field and default to 'Anyone'
+            $viewersOptionsField->setSource($viewersOptionsSource)->setValue('Anyone');
+
+            //group drop down for 'Only these groups' in options set
+            $viewerGroupsField = TreeMultiselectField::create(
+                "ViewerGroups",
+                _t(__class__ . '.VIEWERGROUPS', "Viewer Groups"),
+                Group::class
+            );
+
+            //attach group options and group dropdown
+            $fields->addFieldsToTab('Root.ViewerGroups', [
+                $viewersOptionsField,
+                $viewerGroupsField,
+            ]);
         });
 
         return parent::getCMSFields();


### PR DESCRIPTION
Hey guys,

These changes enable ViewerGroups on individual elements so that individual elements can be hidden from public view and restricted to certain member groups, etc.

I'm keen to know if these are changes you want in the module and what would be needed for you to accept them.

BaseElement:
- Now has Groups (those that can view the element).
- InheritedPermissionsExtension enabled.
- Changed 'canView' to respect viewer settings.
- Existing ViewerGroups/EditorGroups removed.
- New 'ViewerGroups' tab added.
- Added 'Can Edit Type' to Content tab.

***This a remake of https://github.com/dnadesign/silverstripe-elemental/pull/288 to target the 3 branch. As a result of this feedback from @robbieaverill :*

> These changes seem like a good idea. I’ll have a better look at the permission checks on Monday. One thing to be wary of with this kind of thing is full page or partial caching around the elemental area, however it’s often not the responsibility of this module to implement that so it’d be down to devs to do it in a sensible way. Another thing is that master is being rebuilt at the moment, so maybe target the 3 branch (you can change the target branch for PRs via “edit” in top left, then rebase). Thanks for te PR!