### PR TITLE
API Bump minimum SilverStripe version to 4.3 and implement multi-schema GraphQL support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL RECIPE_VERSION=1.2.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     #- php: 7.0
     #  env: DB=PGSQL PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=MYSQL RECIPE_VERSION=1.2.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.2
-      env: DB=MYSQL RECIPE_VERSION=4.2.x-dev BEHAT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev BEHAT_TEST=1
     - php: 7.2
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
 
@@ -38,7 +38,7 @@ before_script:
   # Install composer dependencies
   - composer validate
   - composer require silverstripe/recipe-cms:$RECIPE_VERSION silverstripe/recipe-testing:^1 --no-update
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --no-update; fi
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --no-update; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
   # Behat bootstrapping

--- a/_config/graphql.yml
+++ b/_config/graphql.yml
@@ -1,18 +1,19 @@
 ---
 Name: elementalgraphqlconfig
 ---
-SilverStripe\GraphQL\Controller:
-  schema:
-    scaffolding:
-      types:
-        DNADesign\Elemental\Models\BaseElement:
-          fields: [ID, LastEdited, AbsoluteLink]
-          operations:
-            copyToStage: true
-            readOne: true
-        SilverStripe\Security\Member:
-          fields: [ID, FirstName, Surname]
-          operations:
-            readOne: true
-    typeNames:
-      DNADesign\Elemental\Models\BaseElement: Block
+SilverStripe\GraphQL\Manager:
+  schemas:
+    admin:
+      scaffolding:
+        types:
+          DNADesign\Elemental\Models\BaseElement:
+            fields: [ID, LastEdited, AbsoluteLink]
+            operations:
+              copyToStage: true
+              readOne: true
+          SilverStripe\Security\Member:
+            fields: [ID, FirstName, Surname]
+            operations:
+              readOne: true
+      typeNames:
+        DNADesign\Elemental\Models\BaseElement: Block

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "silverstripe/cms": "^4.2",
+        "silverstripe/cms": "^4.3",
         "silverstripe/versioned-admin": "^1.0",
         "symbiote/silverstripe-gridfieldextensions": "^3.1",
         "silverstripe/vendor-plugin": "^1"


### PR DESCRIPTION
Multi-schema GraphQL support is added in SilverStripe 4.3 with the silverstripe/graphql version bumped from 2.x to 3.x.

This updates that and bumps the minimum SilverStripe version to 4.3.

Note that v4 of elemental (currently master branch) will also be 4.3 minimum, but has Reactified the elemental editor so is a major break.

Required for https://github.com/silverstripe/silverstripe-versioned-admin/pull/33