### PR TITLE
fix(ElementalPageExtension): Update getElementsForSearch() so that it…

### DIFF
--- a/src/Controllers/ElementSiteTreeFilterSearch.php
+++ b/src/Controllers/ElementSiteTreeFilterSearch.php
@@ -32,10 +32,6 @@ class ElementSiteTreeFilterSearch extends CMSSiteTreeFilter_Search
             return parent::applyDefaultFilters($query);
         }
 
-        // Enable frontend themes in order to correctly render the elements as they would be for the frontend
-        Config::nest();
-        SSViewer::set_themes(SSViewer::config()->get('themes'));
-
         // Get an array of SiteTree record IDs that match the search term in nested element data
         /** @var ArrayList $siteTrees */
         $siteTrees = $query->filterByCallback(function (SiteTree $siteTree) {
@@ -48,9 +44,6 @@ class ElementSiteTreeFilterSearch extends CMSSiteTreeFilter_Search
             $pageContent = $siteTree->getElementsForSearch();
             return (bool) stripos($pageContent, $this->params['Term']) !== false;
         });
-
-        // Return themes back for the CMS
-        Config::unnest();
 
         if ($siteTrees->count()) {
             // Apply the list of IDs as an extra filter


### PR DESCRIPTION
Update getElementsForSearch() so that it switches to the frontend theme. This is to fix a regression from SilverStripe 3.X when [HeyDay/Elastica](https://github.com/heyday/silverstripe-elastica) is configured to write the `ElementsForSearch` field.

Also as noted in the following PR https://github.com/dnadesign/silverstripe-elemental/pull/343, the implementation of switching themes is technically incorrect. The only reason I noticed for this PR is that if you don't set the theme back, the CMS layout breaks after a user presses "Save" in the CMS. (its as if the flex boxes stop applying spacing, everything shifts next to each other)

**Needs after merge**
- Can this please be cherry picked into 2.X branch and tagged for SilverStripe 4.1 support please?

**Config:**
```yml
---
Name: extensible-elastic-config
---
Page:
  indexed_fields: &page_defaults
    -
      ClassName:
        type: keyword
    - Title
    - Content
    -
      LastEdited:
        type: date
    -
      ElementsForSearch:
        type: text
```

**Current in-project workaround**

Modify `Page.php`
```php
/**
 * @return string
 */
public function getElementsForSearch(): string
{
    // NOTE(Jake): 2018-08-22
    //
    // Workaround bug where this function doesn't reset back to default theme.
    // A PR has been made here:
    // - https://github.com/dnadesign/silverstripe-elemental/pull/342
    //
    // However I was unable to run a fork of this branch because its Elemental 3.0
    // which is SilverStripe 4.2+. So I've requested on the PR if they can cherry
    // pick it back into 2.x.
    //
    // Remove this entire function if this PR gets merged and Elemental gets updated.
    //
    $result = '';
    $instance = $this->getExtensionInstance(ElementalPageExtension::class);
    if (!$instance) {
        throw new Exception('Missing ElementalPageExtension extension.');
    }
    $oldThemes = SSViewer::get_themes();
    SSViewer::set_themes(SSViewer::config()->get('themes'));
    try {
        $instance->setOwner($this);
        $result = $instance->getElementsForSearch();
        $instance->clearOwner();
    } finally {
        // Reset theme if an exception occurs, if you don't have a
        // try / finally around code that might throw an Exception,
        // CMS layout can break on the response. (SilverStripe 4.1.1)
        SSViewer::set_themes($oldThemes);
    }
    return $result;
}
```