### PR TITLE
remove(ElementSiteTreeFilterSearch): Remove erroneous implementation of SSVIewer::set_themes() for getElementsForSearch

### DIFF
--- a/src/Controllers/ElementSiteTreeFilterSearch.php
+++ b/src/Controllers/ElementSiteTreeFilterSearch.php
@@ -32,10 +32,6 @@ class ElementSiteTreeFilterSearch extends CMSSiteTreeFilter_Search
             return parent::applyDefaultFilters($query);
         }
 
-        // Enable frontend themes in order to correctly render the elements as they would be for the frontend
-        Config::nest();
-        SSViewer::set_themes(SSViewer::config()->get('themes'));
-
         // Get an array of SiteTree record IDs that match the search term in nested element data
         /** @var ArrayList $siteTrees */
         $siteTrees = $query->filterByCallback(function (SiteTree $siteTree) {
@@ -48,9 +44,6 @@ class ElementSiteTreeFilterSearch extends CMSSiteTreeFilter_Search
             $pageContent = $siteTree->getElementsForSearch();
             return (bool) stripos($pageContent, $this->params['Term']) !== false;
         });
-
-        // Return themes back for the CMS
-        Config::unnest();
 
         if ($siteTrees->count()) {
             // Apply the list of IDs as an extra filter


### PR DESCRIPTION
This is dependent on https://github.com/dnadesign/silverstripe-elemental/pull/342 getting merged.

**The problem**
SSViewer::set_themes() does not affect the config system at all. At least in SilverStripe Framework 4.1.1
```
/**
     * Assign the list of active themes to apply.
     * If default themes should be included add $default as the last entry.
     *
     * @param array $themes
     */
    public static function set_themes($themes = [])
    {
        static::$current_themes = $themes;
    }
```

So we're basically nesting/unnesting configs unnecessarily here. This is also probably the incorrect place to put this logic, a much more logical place would be here on `ElementalPageExtension::getElementsForSearch` so that third party libraries can use it in any context.

**The solution**
- Accept the following PR: https://github.com/dnadesign/silverstripe-elemental/pull/342
- Accept this PR.