### PR TITLE
NEW Adding controller to expose form schema endpoint for elemental blocks

### DIFF
--- a/src/Controllers/ElementalAreaController.php
+++ b/src/Controllers/ElementalAreaController.php
@@ -1,0 +1,64 @@
+<?php
+namespace DNADesign\Elemental\Controllers;
+
+use DNADesign\Elemental\Models\BaseElement;
+use SilverStripe\Admin\LeftAndMain;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forms\DefaultFormFactory;
+use SilverStripe\Forms\Form;
+
+/**
+ * Controller for "ElementalArea" - handles loading and saving of in-line edit forms in an elemental area in admin
+ */
+class ElementalAreaController extends LeftAndMain
+{
+    private static $url_segment = 'element-area';
+
+    private static $ignore_menuitem = true;
+
+    private static $allowed_actions = array(
+        'elementForm',
+        'schema',
+    );
+
+    /**
+     * @param HTTPRequest|null $request
+     * @return Form
+     * @throws \SilverStripe\Control\HTTPResponse_Exception
+     */
+    public function elementForm(HTTPRequest $request = null)
+    {
+        // Get ID either from posted back value, or url parameter
+        if (!$request) {
+            $this->jsonError(400);
+            return null;
+        }
+        $id = $request->param('ID');
+        if (!$id) {
+            $this->jsonError(400);
+            return null;
+        }
+        return $this->getElementForm($id) ?: $this->jsonError(404);
+    }
+
+    /**
+     * @param int $elementID
+     * @return Form|null Returns null if no element exists for the given ID
+     */
+    public function getElementForm($elementID)
+    {
+        $scaffolder = Injector::inst()->get(DefaultFormFactory::class);
+        $element = BaseElement::get()->byID($elementID);
+
+        if (!$element) {
+            return null;
+        }
+
+        return $scaffolder->getForm(
+            $this,
+            'ElementForm_'.$elementID,
+            ['Record' => $element]
+        );
+    }
+}


### PR DESCRIPTION
This PR is heavily influenced by [asset-admin](https://github.com/silverstripe/silverstripe-asset-admin/blob/2c8cf959cc6ad09d3549b8f68c76e2abada8a1a3/code/Controller/AssetAdmin.php#L926). First time I've messed around with form schema endpoints. I'm possibly missing something. But in my testing this will drive a `FormBuilderLoader` for the most part