### PR TITLE
FIX Use cachable call to get page version from draft stage

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -92,6 +92,14 @@ class BaseElement extends DataObject
      */
     protected $controller;
 
+    /**
+     * Cache various data to improve CMS load time
+     *
+     * @internal
+     * @var array
+     */
+    protected $cacheData;
+
     private static $default_sort = 'Sort';
 
     private static $singular_name = 'block';
@@ -448,10 +456,16 @@ class BaseElement extends DataObject
      */
     public function getPage()
     {
+        // Allow for repeated calls to be cached
+        if (isset($this->cacheData['page'])) {
+            return $this->cacheData['page'];
+        }
+
         $area = $this->Parent();
 
         if ($area instanceof ElementalArea && $area->exists()) {
-            return $area->getOwnerPage();
+            $this->cacheData['page'] = $area->getOwnerPage();
+            return $this->cacheData['page'];
         }
 
         return null;
@@ -571,8 +585,13 @@ class BaseElement extends DataObject
      */
     public function CMSEditLink()
     {
+        // Allow for repeated calls to be returned from cache
+        if (isset($this->cacheData['cms_edit_link'])) {
+            return $this->cacheData['cms_edit_link'];
+        }
+
         $relationName = $this->getAreaRelationName();
-        $page = $this->getPage(true);
+        $page = $this->getPage();
 
         if (!$page) {
             return null;
@@ -601,6 +620,7 @@ class BaseElement extends DataObject
 
         $this->extend('updateCMSEditLink', $link);
 
+        $this->cacheData['cms_edit_link'] = $link;
         return $link;
     }
 
@@ -613,7 +633,14 @@ class BaseElement extends DataObject
      */
     public function getAreaRelationName()
     {
+        // Allow repeated calls to return from internal cache
+        if (isset($this->cacheData['area_relation_name'])) {
+            return $this->cacheData['area_relation_name'];
+        }
+
         $page = $this->getPage();
+
+        $result = 'ElementalArea';
 
         if ($page) {
             $has_one = $page->config()->get('has_one');
@@ -624,12 +651,14 @@ class BaseElement extends DataObject
                     continue;
                 }
                 if ($relationClass === $area->ClassName && $page->{$relationName}()->ID === $area->ID) {
-                    return $relationName;
+                    $result = $relationName;
+                    break;
                 }
             }
         }
 
-        return 'ElementalArea';
+        $this->cacheData['area_relation_name'] = $result;
+        return $result;
     }
 
     /**

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -154,11 +154,11 @@ class ElementalArea extends DataObject
                 $areaID = $eaRelationship . 'ID';
 
                 $currentStage = Versioned::get_stage() ?: Versioned::DRAFT;
-                $page = Versioned::get_by_stage($class, $currentStage)->filter($areaID, $this->ID);
+                $page = Versioned::get_one_by_stage($class, $currentStage, "\"$areaID\" = {$this->ID}");
 
 
-                if ($page && $page->exists()) {
-                    return $page->first();
+                if ($page) {
+                    return $page;
                 }
             }
         }
@@ -172,11 +172,15 @@ class ElementalArea extends DataObject
 
             foreach ($elementalAreaRelations as $eaRelationship) {
                 $areaID = $eaRelationship . 'ID';
-                $page = Versioned::get_by_stage($class, Versioned::DRAFT)->filter($areaID, $this->ID);
+                $page = Versioned::get_one_by_stage($class, Versioned::DRAFT, "\"$areaID\" = {$this->ID}");
 
-                if ($page && $page->exists()) {
-                    $this->OwnerClassName = $class;
-                    return $page->first();
+                if ($page) {
+                    if ($this->OwnerClassName !== $class) {
+                        $this->OwnerClassName = $class;
+                        $this->write();
+                    }
+
+                    return $page;
                 }
             }
         }

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -56,6 +56,14 @@ class ElementalArea extends DataObject
     private static $table_name = 'ElementalArea';
 
     /**
+     * Cache various data to improve CMS load time
+     *
+     * @internal
+     * @var array
+     */
+    protected $cacheData = [];
+
+    /**
      * @return array
      */
     public function supportedPageTypes()
@@ -142,6 +150,11 @@ class ElementalArea extends DataObject
      */
     public function getOwnerPage()
     {
+        // Allow for repeated calls to read from cache
+        if (isset($this->cacheData['owner_page'])) {
+            return $this->cacheData['owner_page'];
+        }
+
         if ($this->OwnerClassName) {
             $class = $this->OwnerClassName;
             $instance = Injector::inst()->get($class);
@@ -156,8 +169,8 @@ class ElementalArea extends DataObject
                 $currentStage = Versioned::get_stage() ?: Versioned::DRAFT;
                 $page = Versioned::get_one_by_stage($class, $currentStage, "\"$areaID\" = {$this->ID}");
 
-
                 if ($page) {
+                    $this->cacheData['owner_page'] = $page;
                     return $page;
                 }
             }
@@ -180,6 +193,7 @@ class ElementalArea extends DataObject
                         $this->write();
                     }
 
+                    $this->cacheData['area_relation_name'] = $page;
                     return $page;
                 }
             }


### PR DESCRIPTION
Profiling suggests that 50% of the request calls are spent getting the owner page. This change allows Versioned to cache those calls, reducing the CMS page edit form load time by ~50%

This also removes around ~300ms with 100 blocks by internally caching some of the most used ORM calls.

Issue: #368