### PR TITLE
FIX Re-enable Behat tests by adding to FeatureContext

### DIFF
--- a/tests/Behat/Context/FeatureContext.php
+++ b/tests/Behat/Context/FeatureContext.php
@@ -7,10 +7,11 @@ use SilverStripe\BehatExtension\Context\SilverStripeContext;
 if (!class_exists(SilverStripeContext::class)) {
     return;
 }
+
 class FeatureContext extends SilverStripeContext
 {
     /**
-     * @Then /^I should( not |\s*)see the edit form for block (\d+)$/i
+     * @Then /^I should( not |\s+)see the edit form for block (\d+)$/i
      */
     public function iShouldSeeTheEditFormForBlock($negative, $position)
     {
@@ -21,10 +22,10 @@ class FeatureContext extends SilverStripeContext
         $form = $block->find('css', '.element-editor-editform');
 
         if ($iShouldNotSee) {
-            assert(!$form || !$form->isVisible(), 'I see the form! Try again later.');
+            assertTrue(!$form || !$form->isVisible(), 'I see the form! Try again later.');
         } else {
             assertNotNull($form, 'Edit form not found');
-            assert($form->isVisible());
+            assertTrue($form->isVisible());
         }
     }
 
@@ -64,8 +65,6 @@ class FeatureContext extends SilverStripeContext
         assertNotNull($button, 'Caret button for block ' . $position . ' was not found in the page.');
         $button->click();
     }
-
-
 
     /**
      * @Then I should see :text as the title for block :position
@@ -178,7 +177,7 @@ class FeatureContext extends SilverStripeContext
     /**
      * Returns the caret button for a specific block
      *
-     * @param $block
+     * @param NodeElement $block
      * @return NodeElement
      */
     protected function getCaretButton($block)

--- a/tests/Behat/features/element-editor.feature
+++ b/tests/Behat/features/element-editor.feature
@@ -26,11 +26,11 @@ Feature: View types of elements in an area on a page
       Given I see a list of blocks
       Then I should see block 1
       # The entire block should be clickable to reveal the form
-      Given I click on block 1
+      When I click on block 1
       Then I should see the edit form for block 1
         And I should see "Title (displayed if checked)"
         And the "HTML" HTML field should contain "Some content"
-      Given I click on the caret button for block 1
+      When I click on the caret button for block 1
       # The form should still exist, just be hidden from the user
       Then I should not see the edit form for block 1
         And the "HTML" HTML field should contain "Some content"


### PR DESCRIPTION
Resolves #382 

This PR adds three custom functions to the feature context to allow the tests to assert that the edit form exists and/or is visible to the CMS user. As a pleasant side effect the custom functions should make the tests more readable as well.