### PR TITLE
FIX Add namespaces to inline edit form field names

### DIFF
--- a/src/Forms/EditFormFactory.php
+++ b/src/Forms/EditFormFactory.php
@@ -56,6 +56,6 @@ class EditFormFactory extends DefaultFormFactory
         foreach ($fields->dataFields() as $field) {
             $namespacedName = sprintf(self::FIELD_NAMESPACE_TEMPLATE, $elementID, $field->getName());
             $field->setName($namespacedName);
-        };
+        }
     }
 }

--- a/src/Forms/EditFormFactory.php
+++ b/src/Forms/EditFormFactory.php
@@ -4,16 +4,27 @@ namespace DNADesign\Elemental\Forms;
 
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Forms\DefaultFormFactory;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 
 class EditFormFactory extends DefaultFormFactory
 {
+    /**
+     * @var string
+     */
+    const FIELD_NAMESPACE_TEMPLATE = 'PageElements_%d_%s';
+
     public function getForm(RequestHandler $controller = null, $name = self::DEFAULT_NAME, $context = [])
     {
         $form = parent::getForm($controller, $name, $context);
 
         // Remove divider lines between form fields
         $form->addExtraClass('form--no-dividers');
+
+        // Namespace all fields - do this after getting getFormFields so they still get populated
+        $formFields = $form->Fields();
+        $this->namespaceFields($formFields, $context);
+        $form->setFields($formFields);
 
         return $form;
     }
@@ -29,5 +40,22 @@ class EditFormFactory extends DefaultFormFactory
         }
 
         return $fields;
+    }
+
+    /**
+     * Given a {@link FieldList}, give all fields a unique name so they can be used in the same context as
+     * other elemental edit forms and the page (or other DataObject) that owns them.
+     *
+     * @param FieldList $fields
+     * @param array $context
+     */
+    protected function namespaceFields(FieldList $fields, array $context)
+    {
+        $elementID = $context['Record']->ID;
+
+        foreach ($fields->dataFields() as $field) {
+            $namespacedName = sprintf(self::FIELD_NAMESPACE_TEMPLATE, $elementID, $field->getName());
+            $field->setName($namespacedName);
+        };
     }
 }

--- a/tests/Behat/features/add-block-element.feature
+++ b/tests/Behat/features/add-block-element.feature
@@ -22,6 +22,7 @@ Feature: Add elements in the CMS
     Then I select "Content" from "elemental-editor_add-new-block-control_select-dropdown"
       And I click "Add" in the ".elemental-editor__add-new-block-control" element
       And I fill in "Eve's Block" for "Title"
+      # Note: using un-namespaced fields in PHP GridField
       And I fill in "<p>Some content III</p>" for the "HTML" HTML field
       And I press the "Create" button
     Then I should see a "Saved content block" message

--- a/tests/Behat/features/edit-block-element.feature
+++ b/tests/Behat/features/edit-block-element.feature
@@ -25,9 +25,10 @@ Feature: Edit elements in the CMS
 
     Given I click on block 1
     Then I should see "Alice's Block"
-      And the "HTML" HTML field should contain "Some content"
+      And the "Content" field should contain "Some content"
 
     Given I fill in "Eve's Block" for "Title"
+      # Note: using un-namespaced fields in PHP GridField
       And I fill in "<p>New sample content</p>" for the "HTML" HTML field
       And I press the "Publish" button
     Then I should see a "Published content block" message
@@ -43,4 +44,4 @@ Feature: Edit elements in the CMS
 
     Given I click on block 2
     Then I should see "Bob's Block"
-      And the "HTML" HTML field should contain "Some content II"
+      And the "Content" field should contain "Some content II"

--- a/tests/Behat/features/element-editor.feature
+++ b/tests/Behat/features/element-editor.feature
@@ -29,11 +29,11 @@ Feature: View types of elements in an area on a page
       When I click on block 1
       Then I should see the edit form for block 1
         And I should see "Title (displayed if checked)"
-        And the "HTML" HTML field should contain "Some content"
+        And the "Content" field should contain "Some content"
       When I click on the caret button for block 1
       # The form should still exist, just be hidden from the user
       Then I should not see the edit form for block 1
-        And the "HTML" HTML field should contain "Some content"
+        And the "Content" field should contain "Some content"
         # The content shows in the preview when the form is not shown
         And I should see "Some content"
 

--- a/tests/Forms/EditFormFactoryTest.php
+++ b/tests/Forms/EditFormFactoryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DNADesign\Elemental\Tests\Forms;
+
+use DNADesign\Elemental\Forms\EditFormFactory;
+use DNADesign\Elemental\Models\ElementContent;
+use SilverStripe\Dev\SapphireTest;
+
+class EditFormFactoryTest extends SapphireTest
+{
+    protected static $fixture_file = 'EditFormFactoryTest.yml';
+
+    public function testFormFieldsHaveNamespaces()
+    {
+        /** @var ElementContent $record */
+        $record = $this->objFromFixture(ElementContent::class, 'content_block');
+
+        $factory = new EditFormFactory();
+        $result = $factory->getForm(null, 'FooForm', ['Record' => $record]);
+        $fields = $result->Fields();
+
+        $this->assertNotNull($fields->dataFieldByName('PageElements_' . $record->ID . '_Title'));
+    }
+}

--- a/tests/Forms/EditFormFactoryTest.yml
+++ b/tests/Forms/EditFormFactoryTest.yml
@@ -1,0 +1,4 @@
+DNADesign\Elemental\Models\ElementContent:
+  content_block:
+    Title: Foo bar
+    HTML: <p>Some content</p>


### PR DESCRIPTION
This ensures that inline edit forms don't conflict with each other or the page that they're rendered in.

I would've liked the format to be `PageElements[123][FieldName]` but either the silverstripe-admin module or react-form package have trouble matching the form state value against the field when it has brackets in the name like this. The data is all in the state correctly, but doesn't end up in the form field.

At least for now we can look for all request vars that start with `PageElements_` and process those, rather than looping an array from HTML inputs.

Resolves #381