### PR TITLE
Check object exists before pushing History Tab to BaseElement

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -300,15 +300,18 @@ class BaseElement extends DataObject
                 $fields->removeByName('Style');
             }
 
-            // Support for new history viewer in SS 4.2+
-            if (class_exists(HistoryViewerField::class)) {
-                Requirements::javascript('dnadesign/silverstripe-elemental:client/dist/js/bundle.js');
+            // Check object exists before pushing History Tab
+            if($this->ID) {
+              // Support for new history viewer in SS 4.2+
+              if (class_exists(HistoryViewerField::class)) {
+                  Requirements::javascript('dnadesign/silverstripe-elemental:client/dist/js/bundle.js');
 
-                $historyViewer = HistoryViewerField::create('ElementHistory');
-                $fields->addFieldToTab('Root.History', $historyViewer);
+                  $historyViewer = HistoryViewerField::create('ElementHistory');
+                  $fields->addFieldToTab('Root.History', $historyViewer);
 
-                $fields->fieldByName('Root.History')
-                    ->addExtraClass('elemental-block__history-tab tab--history-viewer');
+                  $fields->fieldByName('Root.History')
+                      ->addExtraClass('elemental-block__history-tab tab--history-viewer');
+              }
             }
         });
 

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -300,18 +300,15 @@ class BaseElement extends DataObject
                 $fields->removeByName('Style');
             }
 
-            // Check object exists before pushing History Tab
-            if($this->ID) {
-              // Support for new history viewer in SS 4.2+
-              if (class_exists(HistoryViewerField::class)) {
-                  Requirements::javascript('dnadesign/silverstripe-elemental:client/dist/js/bundle.js');
+            // Support for new history viewer in SS 4.2+
+            if ($this->isInDB() && class_exists(HistoryViewerField::class)) {
+                Requirements::javascript('dnadesign/silverstripe-elemental:client/dist/js/bundle.js');
 
-                  $historyViewer = HistoryViewerField::create('ElementHistory');
-                  $fields->addFieldToTab('Root.History', $historyViewer);
+                $historyViewer = HistoryViewerField::create('ElementHistory');
+                $fields->addFieldToTab('Root.History', $historyViewer);
 
-                  $fields->fieldByName('Root.History')
-                      ->addExtraClass('elemental-block__history-tab tab--history-viewer');
-              }
+                $fields->fieldByName('Root.History')
+                    ->addExtraClass('elemental-block__history-tab tab--history-viewer');
             }
         });
 


### PR DESCRIPTION
Hello,
This is a quick fix relative to issue #390 .
I tested it and it does prevent the history tab from showing (duh!).
I used a separate logic block rather than adding an && condition because I assume the inner logic block will be removed in future instances and this way you can just take away the inner condition. Not rocket science obviously.

Thanks for the module again.