### PR TITLE
NEW Add flag to hide the nav tabs in the editable form

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -341,6 +341,10 @@ class BaseElement extends DataObject
                 $fields->fieldByName('Root.History')
                     ->addExtraClass('elemental-block__history-tab tab--history-viewer');
             }
+
+            // Hide the navigation section of the tabs in the React component {@see silverstripe/admin Tabs}
+            $rootTabset = $fields->fieldByName('Root');
+            $rootTabset->setSchemaState(['hideNav' => true]);
         });
 
         return parent::getCMSFields();


### PR DESCRIPTION
The changes in this PR provide a prop to admin's `Tabs` component to hide the form tabs when the inline editable view for individual blocks is expanded:

![image](https://user-images.githubusercontent.com/14869519/45650089-4d4ce500-bb21-11e8-8171-12d987025c5f.png)

--------
Relies on https://github.com/silverstripe/silverstripe-admin/pull/647 and https://github.com/silverstripe/silverstripe-framework/pull/8378