### PR TITLE
ENHANCEMENT: Writeable local cache API

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -676,7 +676,8 @@ class BaseElement extends DataObject
             }
         }
 
-        $this->cacheData['area_relation_name'] = $result;
+        $this->setAreaRelationNameCache($result);
+
         return $result;
     }
 

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -375,7 +375,7 @@ class BaseElement extends DataObject
      * @param string $name
      * @return $this
      */
-    public function setAreaRelationNameCache(string $name)
+    public function setAreaRelationNameCache($name)
     {
         $this->cacheData['area_relation_name'] = $name;
 

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -372,6 +372,17 @@ class BaseElement extends DataObject
     }
 
     /**
+     * @param string $name
+     * @return $this
+     */
+    public function setAreaRelationNameCache(string $name)
+    {
+        $this->cacheData['area_relation_name'] = $name;
+
+        return $this;
+    }
+
+    /**
      * @return Controller
      */
     public function Top()

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -8,6 +8,7 @@ use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
@@ -85,6 +86,41 @@ class ElementalArea extends DataObject
     public function forTemplate()
     {
         return $this->renderWith(static::class);
+    }
+
+    /**
+     * @param ArrayList $elements
+     * @return $this
+     */
+    public function setElementsCached(ArrayList $elements)
+    {
+        $this->cacheData['elements'] = $elements;
+
+        return $this;
+    }
+
+    /**
+     * @param DataObject $page
+     * @return $this
+     */
+    public function setOwnerPageCached(DataObject $page)
+    {
+        $this->cacheData['owner_page'] = $page;
+
+        return $this;
+    }
+
+    /**
+     * A cache-aware accessor for the elements
+     * @return ArrayList|DataList
+     */
+    public function Elements()
+    {
+        if (isset($this->cacheData['elements'])) {
+            return $this->cacheData['elements'];
+        }
+
+        return parent::Elements();
     }
 
     /**

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -185,7 +185,7 @@ class ElementalArea extends DataObject
 
             foreach ($elementalAreaRelations as $eaRelationship) {
                 $areaID = $eaRelationship . 'ID';
-                $page = Versioned::get_one_by_stage($class, Versioned::DRAFT, "\"$areaID\" = {$this->ID}");
+                $page = Versioned::get_by_stage($class, Versioned::DRAFT)->filter($areaID, $this->ID)->first();
 
                 if ($page) {
                     if ($this->OwnerClassName !== $class) {

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -112,7 +112,7 @@ class ElementalArea extends DataObject
 
     /**
      * A cache-aware accessor for the elements
-     * @return ArrayList|DataList
+     * @return ArrayList|DataList|BaseElement[]
      */
     public function Elements()
     {
@@ -206,7 +206,7 @@ class ElementalArea extends DataObject
                 $page = Versioned::get_by_stage($class, $currentStage)->filter($areaID, $this->ID)->first();
 
                 if ($page) {
-                    $this->cacheData['owner_page'] = $page;
+                    $this->setOwnerPageCached($page);
                     return $page;
                 }
             }

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -185,7 +185,7 @@ class ElementalArea extends DataObject
 
             foreach ($elementalAreaRelations as $eaRelationship) {
                 $areaID = $eaRelationship . 'ID';
-                $page = Versioned::get_by_stage($class, Versioned::DRAFT)->filter($areaID, $this->ID)->first();
+                $page = Versioned::get_one_by_stage($class, Versioned::DRAFT, "\"$areaID\" = {$this->ID}");
 
                 if ($page) {
                     if ($this->OwnerClassName !== $class) {

--- a/tests/ElementalAreaTest.php
+++ b/tests/ElementalAreaTest.php
@@ -132,4 +132,18 @@ class ElementalAreaTest extends SapphireTest
         $this->assertInstanceOf(ArrayList::class, $result);
         $this->assertEmpty($result);
     }
+
+    public function testElementsListIsCached()
+    {
+        $area = new ElementalArea();
+
+        $element = new ElementContent();
+        $element->HTML = 'Test';
+
+        $elements = new ArrayList([$element]);
+
+        $area->setElementsCached($elements);
+
+        $this->assertSame($elements, $area->Elements());
+    }
 }


### PR DESCRIPTION
Allows imperative writes to the cache so that components can be eagerly loaded instead of lazily writing to local cache in accessors. The advantage is that cached values can be bulk assigned (e.g. in a single query).

Tests forthcoming upon approval of general approach.