### PR TITLE
FIX Do not write during an elemental owners getCMSFields operation

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -164,14 +164,6 @@ class ElementalAreasExtension extends DataExtension
 
             $area = $this->owner->$eaRelationship();
 
-            // if area isn't in the database then force a write so the blocks have a parent ID.
-            if (!$area->isInDb()) {
-                $area->write();
-
-                $this->owner->{$key} = $area->ID;
-                $this->owner->write();
-            }
-
             $editor = ElementalEditor::create($eaRelationship, $area);
             $editor->setTypes($this->getElementalTypes());
 

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -7,6 +7,7 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
@@ -221,7 +222,17 @@ class ElementalArea extends DataObject
 
             foreach ($elementalAreaRelations as $eaRelationship) {
                 $areaID = $eaRelationship . 'ID';
-                $page = Versioned::get_by_stage($class, Versioned::DRAFT)->filter($areaID, $this->ID)->first();
+                try {
+                    $page = Versioned::get_by_stage($class, Versioned::DRAFT)->filter($areaID, $this->ID)->first();
+                } catch (\Exception $ex) {
+                    // Usually this is catching cases where test stubs from other modules are trying to be loaded
+                    // and failing in unit tests.
+                    if (in_array(TestOnly::class, class_implements($class))) {
+                        continue;
+                    }
+                    // Continue as normal...
+                    throw $ex;
+                }
 
                 if ($page) {
                     if ($this->OwnerClassName !== $class) {


### PR DESCRIPTION
This fixes a bug where going back in history to a pre-elemental version of a page would trigger a new ElementalArea to be created and associated with the page, losing all the blocks for the page.

We shouldn't be doing any writing during a getCMSFields operation.

I've also added some error handling for non-existent TestOnly classes because I'm sick of seeing this whenever I run the unit tests: `42S02-1146: Table 'ss_tmpdb_1539358754_5707977.virtualpagetest_classa' doesn't exist`

Fixes #395