### PR TITLE
FIX Remove singleton call and check view permissions on recorded object

### DIFF
--- a/src/GraphQL/ElementsResolver.php
+++ b/src/GraphQL/ElementsResolver.php
@@ -10,7 +10,7 @@ class ElementsResolver implements OperationResolver
 {
     public function resolve($object, array $args, $context, ResolveInfo $info)
     {
-        if (!$object::singleton()->canView($context['currentUser'])) {
+        if (!$object->canView($context['currentUser'])) {
             throw new \Exception('Current user cannot view elements');
         }
 


### PR DESCRIPTION
Partially addresses https://github.com/dnadesign/silverstripe-elemental/issues/426 by ensuring that users with permissions can actually see the elements in a particular areas. The changes in this PR ensure we have access to the record of the object we are checking permissions on.