### PR TITLE
Stop inheritance for disallowed elements

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -81,7 +81,11 @@ class ElementalAreasExtension extends DataExtension
             $availableClasses = ClassInfo::subclassesFor(BaseElement::class);
         }
 
-        $disallowedElements = (array) $config->get('disallowed_elements');
+        if ($config->get('stop_element_inheritance')) {
+            $disallowedElements = (array) $config->get('disallowed_elements', Config::UNINHERITED);
+        } else {
+            $disallowedElements = (array) $config->get('disallowed_elements');
+        }
         $list = array();
 
         foreach ($availableClasses as $availableClass) {


### PR DESCRIPTION
In the config we can set a flag to stop element inheritance - this currently only works for allowed_elements but should also work for disallowed_elements. 

This allows the following example to work correctly:

```yml
Site\PageTypes\Page:
  extensions:
    - DNADesign\Elemental\Extensions\ElementalPageExtension
  disallowed_elements:
    - Site\Elements\ElementAllowedOnSpecialPage

Site\PageTypes\SpecialPage:
  stop_element_inheritance: true
```

