### PR TITLE
FIX Two CMSField fixes (related to UploadField / FileBlock)

### DIFF
--- a/src/Controllers/ElementalAreaController.php
+++ b/src/Controllers/ElementalAreaController.php
@@ -165,6 +165,14 @@ class ElementalAreaController extends CMSMain
         return HTTPResponse::create($body)->addHeader('Content-Type', 'application/json');
     }
 
+    /**
+     * Provides action control for form fields that are request handlers when they're used in an in-line edit form.
+     *
+     * Eg. UploadField
+     *
+     * @param HTTPRequest $request
+     * @return array|HTTPResponse|\SilverStripe\Control\RequestHandler|string
+     */
     public function formAction(HTTPRequest $request)
     {
         $formName = $request->param('FormName');

--- a/src/Controllers/ElementalAreaController.php
+++ b/src/Controllers/ElementalAreaController.php
@@ -144,7 +144,8 @@ class ElementalAreaController extends CMSMain
 
         try {
             $updated = false;
-            $element->update($data);
+
+            $element->updateFromFormData($data);
             // Check if anything will actually be changed before writing
             if ($element->isChanged()) {
                 $element->write();
@@ -193,7 +194,7 @@ class ElementalAreaController extends CMSMain
      * @param int $elementID
      * @return array
      */
-    protected function removeNamespacesFromFields(array $data, $elementID)
+    public static function removeNamespacesFromFields(array $data, $elementID)
     {
         $output = [];
         $template = sprintf(EditFormFactory::FIELD_NAMESPACE_TEMPLATE, $elementID, '');

--- a/src/Controllers/ElementalAreaController.php
+++ b/src/Controllers/ElementalAreaController.php
@@ -29,12 +29,14 @@ class ElementalAreaController extends CMSMain
     private static $url_handlers = [
         // API access points with structured data
         'POST api/saveForm/$ID' => 'apiSaveForm',
+        'POST $FormName/field/$FieldName' => 'formAction',
     ];
 
     private static $allowed_actions = [
         'elementForm',
         'schema',
         'apiSaveForm',
+        'formAction',
     ];
 
     public function getClientConfig()
@@ -161,6 +163,19 @@ class ElementalAreaController extends CMSMain
             'updated' => $updated,
         ]);
         return HTTPResponse::create($body)->addHeader('Content-Type', 'application/json');
+    }
+
+    public function formAction(HTTPRequest $request)
+    {
+        $formName = $request->param('FormName');
+
+        // Get the element ID from the form name
+        $id = substr($formName, strlen(sprintf(self::FORM_NAME_TEMPLATE, '')));
+        $form = $this->getElementForm($id);
+
+        $field = $form->getRequestHandler()->handleField($request);
+
+        return $field->handleRequest($request);
     }
 
     /**

--- a/src/Forms/ElementalAreaField.php
+++ b/src/Forms/ElementalAreaField.php
@@ -241,10 +241,10 @@ class ElementalAreaField extends GridField
                 continue;
             }
 
-            $fields = [];
-
             $fieldNamePrefix = sprintf(EditFormFactory::FIELD_NAMESPACE_TEMPLATE, $elementId, '');
             $prefixLength = strlen($fieldNamePrefix);
+
+            $cmsFields = $element->getCMSFields();
 
             foreach ($data as $field => $datum) {
                 // Check that the field starts with a valid name
@@ -252,10 +252,16 @@ class ElementalAreaField extends GridField
                     continue;
                 }
 
-                $fields[substr($field, $prefixLength)] = $datum;
+                $field = $cmsFields->dataFieldByName(substr($field, $prefixLength));
+
+                if (!$field) {
+                    continue;
+                }
+
+                $field->setSubmittedValue($datum);
+                $field->saveInto($element);
             }
 
-            $element->update($fields);
             $element->write();
         }
     }

--- a/src/Forms/ElementalAreaField.php
+++ b/src/Forms/ElementalAreaField.php
@@ -241,27 +241,9 @@ class ElementalAreaField extends GridField
                 continue;
             }
 
-            $fieldNamePrefix = sprintf(EditFormFactory::FIELD_NAMESPACE_TEMPLATE, $elementId, '');
-            $prefixLength = strlen($fieldNamePrefix);
+            $data = ElementalAreaController::removeNamespacesFromFields($data, $element->ID);
 
-            $cmsFields = $element->getCMSFields();
-
-            foreach ($data as $field => $datum) {
-                // Check that the field starts with a valid name
-                if (strpos($field, $fieldNamePrefix) !== 0) {
-                    continue;
-                }
-
-                $field = $cmsFields->dataFieldByName(substr($field, $prefixLength));
-
-                if (!$field) {
-                    continue;
-                }
-
-                $field->setSubmittedValue($datum);
-                $field->saveInto($element);
-            }
-
+            $element->updateFromFormData($data);
             $element->write();
         }
     }

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -3,6 +3,7 @@
 namespace DNADesign\Elemental\Models;
 
 use DNADesign\Elemental\Controllers\ElementController;
+use DNADesign\Elemental\Forms\EditFormFactory;
 use DNADesign\Elemental\Forms\TextCheckboxGroupField;
 use DNADesign\Elemental\ORM\FieldType\DBObjectType;
 use Exception;
@@ -467,6 +468,27 @@ class BaseElement extends DataObject
         }
 
         return $templateFlat;
+    }
+
+    /**
+     * Given form data (wit
+     *
+     * @param $data
+     */
+    public function updateFromFormData($data)
+    {
+        $cmsFields = $this->getCMSFields();
+
+        foreach ($data as $field => $datum) {
+            $field = $cmsFields->dataFieldByName($field);
+
+            if (!$field) {
+                continue;
+            }
+
+            $field->setSubmittedValue($datum);
+            $field->saveInto($this);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #452

- Fields that are also request handlers are now supported
- Fields that have submitted values different from saved values are now supported