### PR TITLE
Rename CssStyle to StyleVariant

### DIFF
--- a/templates/DNADesign/Elemental/Models/ElementContent.ss
+++ b/templates/DNADesign/Elemental/Models/ElementContent.ss
@@ -1,4 +1,4 @@
-<div class="content-element__content <% if $Style %>$CssStyle<% end_if %>">
+<div class="content-element__content<% if $Style %> $StyleVariant<% end_if %>">
 	<% if $ShowTitle %>
         <h2 class="content-element__title">$Title</h2>
     <% end_if %>


### PR DESCRIPTION
#466 but for 3.0

When the function `getCssStyles` in `ElementContent` https://github.com/dnadesign/silverstripe-elemental/commit/66e71a6b50b120834cf5168c4cf7e21da72dc577#diff-a2c4c4862111f0aede016c36df808f02L56 was moved to `getStyleVariant` in `BaseElement` https://github.com/dnadesign/silverstripe-elemental/commit/66e71a6b50b120834cf5168c4cf7e21da72dc577#diff-26f48b266e6c8b29c609290ab55822f3R693 the template was not updated. This PR updates the the template to the new function name.