### PR TITLE
Stop inheritance for disallowed elements [3.0 backport]

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -76,7 +76,11 @@ class ElementalAreasExtension extends DataExtension
             $availableClasses = ClassInfo::subclassesFor(BaseElement::class);
         }
 
-        $disallowedElements = (array) $config->get('disallowed_elements');
+        if ($config->get('stop_element_inheritance')) {
+            $disallowedElements = (array) $config->get('disallowed_elements', Config::UNINHERITED);
+        } else {
+            $disallowedElements = (array) $config->get('disallowed_elements');
+        }
         $list = array();
 
         foreach ($availableClasses as $availableClass) {


### PR DESCRIPTION
This was fixed in a PR [here](https://github.com/dnadesign/silverstripe-elemental/pull/447), however this issue is affecting us in 3.0 so here's a backported fix for it.