### PR TITLE
FIX Block types that are in-line editable will have links to their page on reports

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -513,7 +513,7 @@ class BaseElement extends DataObject
     }
 
     /**
-     * @return null|DataObject
+     * @return null|SiteTree
      * @throws \Psr\Container\NotFoundExceptionInterface
      * @throws \SilverStripe\ORM\ValidationException
      */
@@ -662,24 +662,23 @@ class BaseElement extends DataObject
 
         $editLinkPrefix = '';
         if (!$page instanceof SiteTree && method_exists($page, 'CMSEditLink')) {
-            $editLinkPrefix = Controller::join_links($page->CMSEditLink(), 'ItemEditForm');
+            $link = Controller::join_links($page->CMSEditLink(), 'ItemEditForm');
         } else {
-            $editLinkPrefix = Controller::join_links(
+            $link = Controller::join_links(
                 singleton(CMSPageEditController::class)->Link('EditForm'),
                 $page->ID
             );
         }
 
-        $link = Controller::join_links(
-            $editLinkPrefix,
-            'field/' . $relationName . '/item/',
-            $this->ID
-        );
-
-        $link = Controller::join_links(
-            $link,
-            'edit'
-        );
+        // In-line editable blocks should just take you to the page. Editable ones should add the suffix for detail form
+        if (!$this->inlineEditable()) {
+            $link = Controller::join_links(
+                $link,
+                'field/' . $relationName . '/item/',
+                $this->ID,
+                'edit'
+            );
+        }
 
         $this->extend('updateCMSEditLink', $link);
 

--- a/src/Reports/ElementsInUseReport.php
+++ b/src/Reports/ElementsInUseReport.php
@@ -83,7 +83,7 @@ class ElementsInUseReport extends Report
      * @param BaseElement $item
      * @return string
      */
-    protected function getEditLink($value, $item)
+    protected function getEditLink($value, BaseElement $item)
     {
         return sprintf(
             '<a class="grid-field__link" href="%s" title="%s">%s</a>',


### PR DESCRIPTION
Currently the link on reports that takes you to edit a block will take you to the `GridFieldDetailForm` view of the block. Given we now offer in-line editing on a block it makes more sense to take the user to the page where the block exists. 

I don't know why we haven't changed the `CMSEditLink` API for in-line editable blocks but I'm happy to do that instead if we agree that makes more sense.