### PR TITLE
NEW Using the breadcrumbs API of reports if available

### DIFF
--- a/src/Reports/ElementTypeReport.php
+++ b/src/Reports/ElementTypeReport.php
@@ -62,7 +62,8 @@ class ElementTypeReport extends Report
 
     public function columns()
     {
-        $inUseReport = new ElementsInUseReport;
+        // Get from Injector so substitutions are used...
+        $inUseReport = ElementsInUseReport::singleton();
 
         return [
             'Icon' => [
@@ -73,7 +74,9 @@ class ElementTypeReport extends Report
                 'formatting' => function ($value, $item) use ($inUseReport) {
                     return sprintf(
                         '<a class="grid-field__link" href="%s" title="%s">%s</a>',
-                        $inUseReport->getLink('?filters[ClassName]='. $item->ClassName),
+                        $inUseReport->getLink(
+                            '?filters[' . $inUseReport::CLASS_NAME_FILTER_KEY . ']=' . $item->ClassName
+                        ),
                         $item->Type,
                         $item->TypeNice
                     );

--- a/src/Reports/ElementsInUseReport.php
+++ b/src/Reports/ElementsInUseReport.php
@@ -13,6 +13,8 @@ class ElementsInUseReport extends Report
 {
     /**
      * The string used in GET params to filter the records in this report by element type
+     *
+     * @var string
      */
     const CLASS_NAME_FILTER_KEY = 'ClassName';
 
@@ -116,7 +118,7 @@ class ElementsInUseReport extends Report
     }
 
     /**
-     * When used with newer versions of silverstripe-reports this method will automatically be added as breadcrumbs
+     * When used with silverstripe/reports >= 4.4, this method will automatically be added as breadcrumbs
      * leading up to this report.
      *
      * @return ArrayData[]

--- a/src/Reports/ElementsInUseReport.php
+++ b/src/Reports/ElementsInUseReport.php
@@ -6,6 +6,7 @@ use DNADesign\Elemental\Models\BaseElement;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\ORM\DataList;
 use SilverStripe\Reports\Report;
+use SilverStripe\View\ArrayData;
 use SilverStripe\View\Requirements;
 
 class ElementsInUseReport extends Report
@@ -107,6 +108,30 @@ class ElementsInUseReport extends Report
         $field->addExtraClass('elemental-report__grid-field');
 
         return $field;
+    }
+
+    /**
+     * When used with newer versions of silverstripe-reports this method will automatically be added as breadcrumbs
+     * leading up to this report.
+     *
+     * @return ArrayData[]
+     */
+    public function getBreadcrumbs()
+    {
+        $params = $this->getSourceParams();
+
+        // Only apply breadcrumbs if a "ClassName" filter is applied. This implies that we came from the
+        // "element type report".
+        if (!isset($params['ClassName'])) {
+            return [];
+        }
+
+        $report = ElementTypeReport::create();
+
+        return [ArrayData::create([
+            'Title' => $report->title(),
+            'Link' => $report->getLink(),
+        ])];
     }
 
     /**

--- a/src/Reports/ElementsInUseReport.php
+++ b/src/Reports/ElementsInUseReport.php
@@ -11,6 +11,11 @@ use SilverStripe\View\Requirements;
 
 class ElementsInUseReport extends Report
 {
+    /**
+     * The string used in GET params to filter the records in this report by element type
+     */
+    const CLASS_NAME_FILTER_KEY = 'ClassName';
+
     public function title()
     {
         return _t(__CLASS__ . '.ReportTitle', 'Content blocks in use');
@@ -21,8 +26,8 @@ class ElementsInUseReport extends Report
         /** @var DataList $elements */
         $elements = BaseElement::get()->exclude(['ClassName' => BaseElement::class]);
 
-        if (isset($params['ClassName'])) {
-            $className = $this->unsanitiseClassName($params['ClassName']);
+        if (isset($params[static::CLASS_NAME_FILTER_KEY])) {
+            $className = $this->unsanitiseClassName($params[static::CLASS_NAME_FILTER_KEY]);
             $elements = $elements->filter(['ClassName' => $className]);
         }
 
@@ -122,7 +127,7 @@ class ElementsInUseReport extends Report
 
         // Only apply breadcrumbs if a "ClassName" filter is applied. This implies that we came from the
         // "element type report".
-        if (!isset($params['ClassName'])) {
+        if (!isset($params[static::CLASS_NAME_FILTER_KEY])) {
             return [];
         }
 


### PR DESCRIPTION
Using the new feature added in silverstripe/silverstripe-reports#113 this will update the breadcrumbs on the "Elements in use" report so it is a child of the "Element type" report. This code is benign without the right version of reports

Fixes #507 