### PR TITLE
ENHANCEMENT Adjust getType to use singular_name

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -2,7 +2,6 @@ en:
   DNADesign\Elemental\Controllers\ElementalAreaController:
     MENUTITLE: 'Edit Page'
   DNADesign\Elemental\Models\BaseElement:
-    BlockType: Block
     CUSTOM_STYLES: 'Select a style..'
     ExtraCssClassesLabel: 'Custom CSS classes'
     ExtraCssClassesPlaceholder: 'my_class another_class'

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -110,9 +110,9 @@ class BaseElement extends DataObject
 
     private static $default_sort = 'Sort';
 
-    private static $singular_name = 'block';
+    private static $singular_name = 'Block';
 
-    private static $plural_name = 'blocks';
+    private static $plural_name = 'Blocks';
 
     private static $summary_fields = [
         'EditorPreview' => 'Summary'
@@ -344,7 +344,7 @@ class BaseElement extends DataObject
      */
     public function getType()
     {
-        return _t(__CLASS__ . '.BlockType', 'Block');
+        return $this->i18n_singular_name();
     }
 
     /**

--- a/src/Models/ElementContent.php
+++ b/src/Models/ElementContent.php
@@ -15,9 +15,9 @@ class ElementContent extends BaseElement
 
     private static $table_name = 'ElementContent';
 
-    private static $singular_name = 'content block';
+    private static $singular_name = 'Content block';
 
-    private static $plural_name = 'content blocks';
+    private static $plural_name = 'Content blocks';
 
     private static $description = 'HTML text block';
 


### PR DESCRIPTION
Currently developers need to override the `getType` function in order to get a custom block name showing in the dropdown. I think using singular_name as the default makes sense as this covers a common use case for what people may want from `getType`