### PR TITLE
Add $Anchor as class in ElementHolder

### DIFF
--- a/templates/DNADesign/Elemental/Layout/ElementHolder.ss
+++ b/templates/DNADesign/Elemental/Layout/ElementHolder.ss
@@ -1,3 +1,3 @@
-<div class="element $SimpleClassName.LowerCase<% if $StyleVariant %> $StyleVariant<% end_if %><% if $ExtraClass %> $ExtraClass<% end_if %>" id="$Anchor">
+<div class="element $SimpleClassName.LowerCase $Anchor<% if $StyleVariant %> $StyleVariant<% end_if %><% if $ExtraClass %> $ExtraClass<% end_if %>" id="$Anchor">
 	$Element
 </div>


### PR DESCRIPTION
Best practice for CSS requires using classes for styling instead of the IDs. Adding the $Anchor as css class will allow developers to target individual elements with CSS in more standardized way