### PR TITLE
Update travis to still use admin@4.3 for NPM tests in 4.0 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - php: 7.2
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
     - php: 7.2
-      env: DB=MYSQL RECIPE_VERSION=4.x-dev NPM_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev NPM_TEST=1
 
 before_script:
   # Extra $PATH


### PR DESCRIPTION
Currently builds in 4.0 branch will fail using 4.4. We should switch to 4.3 for NPM tests and change it back to 4.x on the merge up to master (which is on React 16 now)