### PR TITLE
FIX Not all form actions are POST

### DIFF
--- a/src/Controllers/ElementalAreaController.php
+++ b/src/Controllers/ElementalAreaController.php
@@ -29,7 +29,7 @@ class ElementalAreaController extends CMSMain
     private static $url_handlers = [
         // API access points with structured data
         'POST api/saveForm/$ID' => 'apiSaveForm',
-        'POST $FormName/field/$FieldName' => 'formAction',
+        '$FormName/field/$FieldName' => 'formAction',
     ];
 
     private static $allowed_actions = [


### PR DESCRIPTION
Fixes #514

Currently the form action handler for elemental areas is set for only POST requests. This is okay for UploadField where it's a file upload handler but it's reasonable that fields like TagField and TreeDropdownField use GET requests.