### PR TITLE
MINOR Avoid fetching owner page when ElementalArea has not been saved

### DIFF
--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -226,7 +226,7 @@ class ElementalArea extends DataObject
 
             $areaIDFilters = [];
             foreach ($instance->getElementalRelations() as $eaRelationship) {
-	            $areaIDFilters[$eaRelationship . 'ID'] = $this->ID;
+                $areaIDFilters[$eaRelationship . 'ID'] = $this->ID;
             }
 
             try {

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -188,7 +188,7 @@ class ElementalArea extends DataObject
     public function getOwnerPage()
     {
         // You can't find the owner page of a area that hasn't been save yet
-        if ($this->ID == 0) {
+        if (!$this->isInDB()) {
             return null;
         }
 


### PR DESCRIPTION
This change does 2 things to speed up `ElementalArea::getOwnerPage()`:
* Start by checking if the ElementalArea has an ID and return null if it doesn't. This is quite beneficial when working with a new ElementalArea, because `null` responses aren't cache.
* Update the logic to find owner page when `OwnerClassName` is unknown. Instead of doing one query for each combination elemental relation of each elemental page type, it will do one query for each elemental page type. It's only going to make a difference if you have pages with multiple elemental areas ... so it's not going to make a difference for most people.

Related to our beloved Key Project.