### PR TITLE
FIX Update GraphQL config and CMS dependancy so we support ^4

### DIFF
--- a/_config/graphql.yml
+++ b/_config/graphql.yml
@@ -17,3 +17,23 @@ SilverStripe\GraphQL\Manager:
               readOne: true
       typeNames:
         DNADesign\Elemental\Models\BaseElement: Block
+
+---
+# This supports older versions of silverstripe-graphql (< 3) but should be benign in other cases
+Name: elementallegacygraphqlconfig
+---
+SilverStripe\GraphQL\Controller:
+  schema:
+    scaffolding:
+      types:
+        DNADesign\Elemental\Models\BaseElement:
+          fields: [ID, LastEdited, AbsoluteLink]
+          operations:
+            copyToStage: true
+            readOne: true
+        SilverStripe\Security\Member:
+          fields: [ID, FirstName, Surname]
+          operations:
+            readOne: true
+    typeNames:
+      DNADesign\Elemental\Models\BaseElement: Block

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "silverstripe/cms": "^4.3",
+        "silverstripe/cms": "^4.2",
         "silverstripe/versioned-admin": "^1.0",
         "symbiote/silverstripe-gridfieldextensions": "^3.1",
         "silverstripe/vendor-plugin": "^1"


### PR DESCRIPTION
Currently the `3` branch has upped `silverstripe/cms` dependancy to `^4.3`. This is because a backwards incompatible change was made to GraphQL scaffolding config. This PR just introduces both configs - thanks to @Cheddam for the idea.

Hopefully there'll be a backwards compatibilty update added to GraphQL 3 in the future to allow us to remove this code.