### PR TITLE
FIX: changing page type to a non-elemental page

### DIFF
--- a/code/extensions/ElementPageExtension.php
+++ b/code/extensions/ElementPageExtension.php
@@ -184,6 +184,7 @@ class ElementPageExtension extends DataExtension
     public function onBeforeWrite()
     {
         if(!$this->supportsElemental()) {
+            parent::onBeforeWrite();
             return;
         }
 
@@ -191,8 +192,7 @@ class ElementPageExtension extends DataExtension
         $originalThemeEnabled = Config::inst()->get('SSViewer', 'theme_enabled');
         Config::inst()->update('SSViewer', 'theme_enabled', true);
 
-
-        if ($this->owner->hasMethod('ElementArea') && Config::inst()->get(__CLASS__, 'copy_element_content_to_contentfield')) {
+        if ($this->owner->hasMethod('ElementArea') && !$this->owner->isChanged('ClassName') && Config::inst()->get(__CLASS__, 'copy_element_content_to_contentfield')) {
             $elements = $this->owner->ElementArea();
 
             if (!$elements->isInDB()) {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		"silverstripe/framework": "~3.1",
 		"silverstripe/cms": "~3.1",
 		"silverstripe/widgets": "~1.1",
-		"symbiote/silverstripe-gridfieldextensions": "~1.0",
+		"symbiote/silverstripe-gridfieldextensions": "~2.0",
 		"symbiote/silverstripe-addressable": "~1.0",
 		"heyday/silverstripe-versioneddataobjects": "~2.0",
 		"undefinedoffset/sortablegridfield": "~0.5"


### PR DESCRIPTION
This fixes some issues with changing a page type away from an elemental supported page in silverstripe 3. 