### PR TITLE
FIX Ensure element orders are persisted to the Live table

### DIFF
--- a/src/Services/ReorderElements.php
+++ b/src/Services/ReorderElements.php
@@ -96,13 +96,13 @@ class ReorderElements
         $baseTableName = Convert::raw2sql(DataObject::getSchema()->tableName(BaseElement::class));
 
         // Update both the draft and live versions of the records
-        $suffixes = [''];
+        $tableNames = [$baseTableName];
         if (BaseElement::has_extension(Versioned::class)) {
-            $suffixes[] = '_Live';
+            $tableNames[] = $element->stageTable($baseTableName, Versioned::LIVE);
         }
 
-        foreach ($suffixes as $tableSuffix) {
-            $tableName = sprintf('"%s%s"', $baseTableName, $tableSuffix);
+        foreach ($tableNames as $tableName) {
+            $tableName = sprintf('"%s"', $tableName);
 
             if ($sortAfterPosition < $currentPosition) {
                 $operator = '+';


### PR DESCRIPTION
Currently when elements are reordered it will ensure the other elements that were affected have their sort order updated - but only on the draft table (ie `Element`). This patch ensures that this change  is also persisted to the live table (ie `Element_Live`).

Fixes #548 