### PR TITLE
FIX Implementing custom read resolver to fix permission issue

### DIFF
--- a/_config/graphql.yml
+++ b/_config/graphql.yml
@@ -27,7 +27,8 @@ SilverStripe\GraphQL\Manager:
               Elements:
                 resolver: DNADesign\Elemental\GraphQL\ElementsResolver
             operations:
-              readOne: true
+              readOne:
+                resolver: DNADesign\Elemental\GraphQL\ReadOneAreaResolver
           # Basic member information is required for history views
           SilverStripe\Security\Member:
             fields: [ID, FirstName, Surname]

--- a/src/GraphQL/ReadOneAreaResolver.php
+++ b/src/GraphQL/ReadOneAreaResolver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DNADesign\Elemental\GraphQL;
+
+use DNADesign\Elemental\Models\ElementalArea;
+use GraphQL\Type\Definition\ResolveInfo;
+use SilverStripe\GraphQL\OperationResolver;
+
+class ReadOneAreaResolver implements OperationResolver
+{
+    public function resolve($object, array $args, $context, ResolveInfo $info)
+    {
+        $area = ElementalArea::get()->byID($args['ID']);
+
+        if (!$area->canView($context['currentUser'])) {
+            throw new \Exception('Current user cannot view element areas');
+        }
+
+        return $area;
+    }
+}

--- a/tests/Behat/features/element-editor.feature
+++ b/tests/Behat/features/element-editor.feature
@@ -6,45 +6,62 @@ Feature: View types of elements in an area on a page
 
   Background:
     Given I add an extension "DNADesign\Elemental\Extensions\ElementalPageExtension" to the "Page" class
+      And a "group" "AUTHOR group" has permissions "Access to 'Pages' section"
       And a "page" "Blocks Page" with a "Alice's Block" content element with "Some content" content
       And the "page" "Blocks Page" has a "Bob's Block" content element with "Some content II" content
 
-    Given I am logged in with "ADMIN" permissions
-      When I go to "/admin/pages"
+  Scenario Outline: I can see the title and summary of each element
+    Given I am logged in with "<group>" permissions
+    When I go to "/admin/pages"
       And I left click on "Blocks Page" in the tree
-    When I see a list of blocks
-      Then I should see "Alice's Block"
-      And I should see "Bob's Block"
-
-  Scenario: I can see the title and summary of each element
-    Given I see a list of blocks
-    Then I should see "Alice's Block" as the title for block 1
+    Then I should see a list of blocks
+      Then I should see "Alice's Block" as the title for block 1
       And I should see "Some content" as the summary for block 1
       And I should see "Bob's Block" as the title for block 2
       And I should see "Some content II" as the summary for block 2
 
+    Examples:
+      | group  |
+      | ADMIN  |
+      | AUTHOR |
+
   Scenario: Opening the "more actions" menu will not expand a block
+    Given I am logged in with "ADMIN" permissions
+    When I go to "/admin/pages"
+    And I left click on "Blocks Page" in the tree
+      Then I should see a list of blocks
+
     When I press the "View actions" button
-    Then I should not see "Title (displayed if checked)"
+      Then I should not see "Title (displayed if checked)"
 
   Scenario: I can see the block type when I hover over an element's icon
-    Given I see a list of blocks
-    When I hover over the icon of block 1
-    Then I should see text matching "Content"
+    Given I am logged in with "ADMIN" permissions
+    When I go to "/admin/pages"
+      And I left click on "Blocks Page" in the tree
+
+    When I see a list of blocks
+      And I hover over the icon of block 1
+      Then I should see text matching "Content"
 
   @unsavedChanges
   Scenario: I can preview a block and hide the form again
-    Given I see a list of blocks
-    Then I should see block 1
+    Given I am logged in with "ADMIN" permissions
+    When I go to "/admin/pages"
+      And I left click on "Blocks Page" in the tree
+    When I see a list of blocks
+      Then I should see block 1
+
     # The entire block should be clickable to reveal the form
     When I click on block 1
-    Then I should see the edit form for block 1
-    And I should see "Title (displayed if checked)"
-    And the "Content" field should contain "Some content"
-    And I fill in "<p>New sample content</p>" for the "Content" HTML field
+     Then I should see the edit form for block 1
+      And I should see "Title (displayed if checked)"
+      And the "Content" field should contain "Some content"
+      And I fill in "<p>New sample content</p>" for the "Content" HTML field
+
     When I click on the caret button for block 1
-    Then I should not see the edit form for block 1
+      Then I should not see the edit form for block 1
+
     # Re-opening the closed form should contain the updated content
     When I click on the caret button for block 1
-    Then I should see the edit form for block 1
-    And the "Content" field should contain "<p>New sample content</p>"
+      Then I should see the edit form for block 1
+      And the "Content" field should contain "<p>New sample content</p>"


### PR DESCRIPTION
This is required because the default  resolver in GraphQL checks permissions against fresh data objects. Elemental areas require that they are saved before permission checks can be accurate

Fixes #586

/cc @scott1702