### PR TITLE
FIX Updating behat tests to not specifically mention page ID

### DIFF
--- a/tests/Behat/features/add-block-element.feature
+++ b/tests/Behat/features/add-block-element.feature
@@ -12,7 +12,8 @@ Feature: Add elements in the CMS
     Given I am logged in with "ADMIN" permissions
       # Remove with 'And I click "Blocks Page" in the ".breadcrumbs-wrapper" element' once the ElementalArea refreshes,
       # See https://github.com/dnadesign/silverstripe-elemental/issues/320
-      And I go to "/admin/pages/edit/show/6"
+      And I go to "/admin/pages"
+      And I left click on "Blocks Page" in the tree
     Then I should see a list of blocks
       And I should see "Alice's Block"
       And I should see "Bob's Block"
@@ -23,7 +24,8 @@ Feature: Add elements in the CMS
     Then I press the "Content" button in the add block popover
     Then I should see "Untitled Content block" as the title for block 1
 
-    When I go to "/admin/pages/edit/show/6"
+    When I go to "/admin/pages"
+    And I left click on "Blocks Page" in the tree
       And I see a list of blocks
     Then I wait 1 second
       And I should see "Untitled Content block"

--- a/tests/Behat/features/archive-block-element.feature
+++ b/tests/Behat/features/archive-block-element.feature
@@ -13,7 +13,8 @@ Feature: Archive elements in the CMS
     Given I am logged in with "ADMIN" permissions
       # Remove with 'And I click "Blocks Page" in the ".breadcrumbs-wrapper" element' once the ElementalArea refreshes,
       # See https://github.com/dnadesign/silverstripe-elemental/issues/320
-      And I go to "/admin/pages/edit/show/6"
+      And I go to "/admin/pages"
+      And I left click on "Blocks Page" in the tree
     When I see a list of blocks
       Then I should see "Alice's Block"
       And I should see "Bob's Block"

--- a/tests/Behat/features/edit-block-element.feature
+++ b/tests/Behat/features/edit-block-element.feature
@@ -12,14 +12,16 @@ Feature: Edit elements in the CMS
     Given I am logged in with "ADMIN" permissions
       # Remove with 'And I click "Blocks Page" in the ".breadcrumbs-wrapper" element' once the ElementalArea refreshes,
       # See https://github.com/dnadesign/silverstripe-elemental/issues/312
-      And I go to "/admin/pages/edit/show/6"
+      And I go to "/admin/pages"
+      And I left click on "Blocks Page" in the tree
     Then I should see a list of blocks
       And I should see "Alice's Block"
       And I should see "Bob's Block"
 
   Scenario: I can edit a non in-line editable block
     Given content blocks are not in-line editable
-      And I go to "/admin/pages/edit/show/6"
+      And I go to "/admin/pages"
+      And I left click on "Blocks Page" in the tree
       And I see a list of blocks
     Then I should see block 1
 
@@ -32,7 +34,8 @@ Feature: Edit elements in the CMS
       And I fill in "<p>New sample content</p>" for the "HTML" HTML field
       And I press the "Publish" button
     Then I should see a "Published content block" message
-    When I go to "/admin/pages/edit/show/6"
+    When I go to "/admin/pages"
+    And I left click on "Blocks Page" in the tree
       And I see a list of blocks
     Then I should see "Eve's Block"
       And I should see "New sample content"

--- a/tests/Behat/features/element-editor.feature
+++ b/tests/Behat/features/element-editor.feature
@@ -10,7 +10,8 @@ Feature: View types of elements in an area on a page
       And the "page" "Blocks Page" has a "Bob's Block" content element with "Some content II" content
 
     Given I am logged in with "ADMIN" permissions
-      And I go to "/admin/pages/edit/show/6"
+      When I go to "/admin/pages"
+      And I left click on "Blocks Page" in the tree
     When I see a list of blocks
       Then I should see "Alice's Block"
       And I should see "Bob's Block"

--- a/tests/Behat/features/empty-element-list.feature
+++ b/tests/Behat/features/empty-element-list.feature
@@ -9,7 +9,8 @@ Feature: View an elemental area with no blocks on a page
       And a "page" "Blocks Page"
 
   Given I am logged in with "ADMIN" permissions
-      And I go to "/admin/pages/edit/show/6"
+      And I go to "/admin/pages"
+      And I left click on "Blocks Page" in the tree
 
   Scenario: I can see a message that alerts me to add blocks
     Given I should see an empty list of blocks

--- a/tests/Behat/features/publish-block-element.feature
+++ b/tests/Behat/features/publish-block-element.feature
@@ -13,7 +13,8 @@ Feature: Publish elements in the CMS
     Given I am logged in with "ADMIN" permissions
       # Remove with 'And I click "Blocks Page" in the ".breadcrumbs-wrapper" element' once the ElementalArea refreshes,
       # See https://github.com/dnadesign/silverstripe-elemental/issues/320
-    And I go to "/admin/pages/edit/show/6"
+    And I go to "/admin/pages"
+    And I left click on "Blocks Page" in the tree
     When I see a list of blocks
     Then I should see "Block A"
     And I should see "Block B"

--- a/tests/Behat/features/unpublish-block-element.feature
+++ b/tests/Behat/features/unpublish-block-element.feature
@@ -13,7 +13,8 @@ Feature: Unpublish elements in the CMS
     Given I am logged in with "ADMIN" permissions
       # Remove with 'And I click "Blocks Page" in the ".breadcrumbs-wrapper" element' once the ElementalArea refreshes,
       # See https://github.com/dnadesign/silverstripe-elemental/issues/320
-    And I go to "/admin/pages/edit/show/6"
+    And I go to "/admin/pages"
+    And I left click on "Blocks Page" in the tree
     When I see a list of blocks
     Then I should see "Block A"
     And I should see "Block B"


### PR DESCRIPTION
Fixes #595

Was easier than exepected... This leverages the feature context within CMS that adds the `I click on "name" in the tree` rule.