### PR TITLE
FIX ElementalAreas should not be shown as part of implicit changesets in campaign admin

### DIFF
--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -55,6 +55,14 @@ class ElementalArea extends DataObject
     private static $table_name = 'ElementalArea';
 
     /**
+     * Don't show this model in campaign admin as part of implicit change sets
+     *
+     * @config
+     * @var bool
+     */
+    private static $hide_in_campaigns = true;
+
+    /**
      * Cache various data to improve CMS load time
      *
      * @internal


### PR DESCRIPTION
Adds configuration to opt ElementalArea out of being displayed as part of implicit changeset items in campaign admin views.

Requires https://github.com/silverstripe/silverstripe-campaign-admin/pull/136

Fixes https://github.com/dnadesign/silverstripe-elemental/issues/593