### PR TITLE
Remove coupling between ElementalArea and SiteTree

### DIFF
--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -3,7 +3,6 @@
 namespace DNADesign\Elemental\Models;
 
 use DNADesign\Elemental\Extensions\ElementalAreasExtension;
-use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injector;
@@ -71,7 +70,7 @@ class ElementalArea extends DataObject
     {
         $elementalClasses = [];
 
-        foreach (ClassInfo::getValidSubClasses(SiteTree::class) as $class) {
+        foreach (ClassInfo::getValidSubClasses(DataObject::class) as $class) {
             if (Extensible::has_extension($class, ElementalAreasExtension::class)) {
                 $elementalClasses[] = $class;
             }


### PR DESCRIPTION
As [briefly discussed on Slack](https://slackarchive.silverstripe.org/slack-archive/message/256649), this is the hotfix I’m currently using with deeply-nested `ElementalAreas`