### PR TITLE
Require Bootstrap ^4.3 in elemental module

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/dnadesign/silverstripe-elemental#readme",
   "dependencies": {
-    "bootstrap": "4.1.2",
+    "bootstrap": "^4.3.1",
     "classnames": "^2.2.5",
     "graphql-tag": "^0.1.17",
     "jquery": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1183,9 +1183,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.2.tgz#aee2a93472e61c471fc79fb475531dcbc87de326"
+bootstrap@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.3.1.tgz#280ca8f610504d99d7b6b4bfc4b68cec601704ac"
 
 boxen@^1.2.1:
   version "1.3.0"


### PR DESCRIPTION
I think it's safe to update from Bootstrap 4.1 to 4.3 in a patch release, since we don't expose any of it through this module, rather using it to build components in the module. Semver implies the changes should be backwards compatible, and if we find something that doesn't match up with that we can patch it in the same patch release for this module we release this PR in.