### PR TITLE
FIX Allow multi readonly trans in TextCheckboxGroupField

### DIFF
--- a/src/Forms/TextCheckboxGroupField.php
+++ b/src/Forms/TextCheckboxGroupField.php
@@ -39,23 +39,27 @@ class TextCheckboxGroupField extends CompositeField
      */
     public function performReadonlyTransformation()
     {
-        $field = parent::performReadonlyTransformation();
+        $field = $this;
 
-        $field->setTemplate(CompositeField::class);
-        $field->setTitle('Title');
+        if (!$this->readonly) {
+            $field = parent::performReadonlyTransformation();
 
-        $field->replaceField('Title', LiteralField::create(
-            'Title',
-            $field->fieldByName('Title')->Value()
-        ));
+            $field->setTemplate(CompositeField::class);
+            $field->setTitle('Title');
 
-        $displayedText = _t(__CLASS__ . '.DISPLAYED', 'Displayed');
-        $notDisplayedText = _t(__CLASS__ . '.NOT_DISPLAYED', 'Not displayed');
+            $field->replaceField('Title', LiteralField::create(
+                'Title',
+                $field->fieldByName('Title')->Value()
+            ));
 
-        $field->replaceField('ShowTitle', LiteralField::create(
-            'ShowTitle',
-            $field->fieldByName('ShowTitle')->Value() === 'Yes' ? $displayedText : $notDisplayedText
-        )->addExtraClass('show-title'));
+            $displayedText = _t(__CLASS__ . '.DISPLAYED', 'Displayed');
+            $notDisplayedText = _t(__CLASS__ . '.NOT_DISPLAYED', 'Not displayed');
+
+            $field->replaceField('ShowTitle', LiteralField::create(
+                'ShowTitle',
+                $field->fieldByName('ShowTitle')->Value() === 'Yes' ? $displayedText : $notDisplayedText
+            )->addExtraClass('show-title'));
+        }
 
         return $field;
     }


### PR DESCRIPTION
Fixes #630. Replaces https://github.com/dnadesign/silverstripe-elemental/pull/635 (rebased on 4.0)

In general, every field in SilverStripe should be able to reliably transform itself into a readonly version. That includes fields which are already readonly, for example ReadonlyField->performReadonlyTransformation() simply returns $this. Most fields don't need the $this->readonly check implemented in here, because they return a different field instead (most of the time a ReadonlyField or LookupField).