### PR TITLE
Save repeated database queries for same ElementalArea (closes #648)

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -525,8 +525,9 @@ class BaseElement extends DataObject
             return $this->cacheData['page'];
         }
 
-        $area = $this->Parent();
 
+        $class = DataObject::getSchema()->hasOneComponent($this, 'Parent');
+        $area = ($this->ParentID) ? DataObject::get_by_id($class, $this->ParentID) : null;
         if ($area instanceof ElementalArea && $area->exists()) {
             $this->cacheData['page'] = $area->getOwnerPage();
             return $this->cacheData['page'];


### PR DESCRIPTION
I left `$this->cacheData['page']` in there for 2 reasons:

1. Playing it safe for BC - it’s not part of the public API, but it’s possible someone could be relying on it
2. It saves repeated schema lookups (I think they’re cached anyway, but it’s still a few less method calls)