### PR TITLE
FIX Remove explicit draft stage query as this breaks non live/stage modes (like archive)

### DIFF
--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -166,8 +166,8 @@ class ElementalArea extends DataObject
             foreach ($elementalAreaRelations as $eaRelationship) {
                 $areaID = $eaRelationship . 'ID';
 
-                $currentStage = Versioned::get_stage() ?: Versioned::DRAFT;
-                $page = Versioned::get_by_stage($class, $currentStage)->filter($areaID, $this->ID)->first();
+                $table = DataObject::getSchema()->tableForField($class, $areaID);
+                $page = DataObject::get_one($class, ["\"{$table}\".\"$areaID\" = ?" => $this->ID]);
 
                 if ($page) {
                     $this->cacheData['owner_page'] = $page;


### PR DESCRIPTION
This took me like 3 hours to track down. The archive mode is not returning correct results as it just returns the latest draft version on anything fetched through this page query. This propegates to children of the page. For example `$element->getOwnerPage()->ElementalArea()->Elements()` are now all draft elements instead of archive elements.