### PR TITLE
FIX Remove the 'add' better button for ElementalAreaField

### DIFF
--- a/src/Forms/ElementalAreaConfig.php
+++ b/src/Forms/ElementalAreaConfig.php
@@ -20,7 +20,7 @@ class ElementalAreaConfig extends GridFieldConfig
         parent::__construct();
 
         $this->addComponent(new GridFieldDeleteAction(false));
-        $this->addComponent(new GridFieldDetailForm());
+        $this->addComponent(new GridFieldDetailForm(null, false, false));
 
         $this->extend('updateConfig');
     }


### PR DESCRIPTION
ElementalAreas use `GridFieldAddNewMultiClass` - this is unsupported by the new add button