### PR TITLE
FIX Don't leave pages in draft when adding ElementalAreasExtension

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -10,10 +10,12 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Model\VirtualPage;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Extensible;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
 
 /**
  * This extension handles most of the relationships between pages and element
@@ -284,7 +286,15 @@ class ElementalAreasExtension extends DataExtension
         }
 
         foreach ($ownerClass::get()->where(implode(' OR ', $where)) as $elementalObject) {
-            $elementalObject->ensureElementalAreasExist($elementalAreas)->write();
+            $needsPublishing = Extensible::has_extension($elementalObject, Versioned::class)
+                && $elementalObject->isPublished();
+
+            /** @var ElementalAreasExtension $elementalObject */
+            $elementalObject->ensureElementalAreasExist($elementalAreas);
+            $elementalObject->write();
+            if ($needsPublishing) {
+                $elementalObject->publishRecursive();
+            }
         }
     }
 }


### PR DESCRIPTION
Currently when adding the `ElementalAreasExtension` to existing pages, they are pulled from published to draft. This patch ensures the page remains published provided it was already fully published.

Fixes #668