### PR TITLE
FIX ElementalCMSMainExtension is now enabled, fixes double search class filter 'All pages'

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -16,6 +16,10 @@ SilverStripe\CMS\Controllers\ContentController:
   url_handlers:
     'element/$ID!': 'handleElement'
 
+SilverStripe\CMS\Controllers\CMSMain:
+  extensions:
+    - DNADesign\Elemental\Extensions\ElementalCMSMainExtension
+
 SilverStripe\Versioned\VersionedGridFieldItemRequest:
   extensions:
     - 'DNADesign\Elemental\Extensions\GridFieldDetailFormItemRequestExtension'


### PR DESCRIPTION
Fixes https://github.com/dnadesign/silverstripe-elemental/issues/366 again