### PR TITLE
Fix incorrect ElementalArea.OwnerClassName on save

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -257,6 +257,13 @@ class ElementalAreasExtension extends DataExtension
                 $area->OwnerClassName = get_class($this->owner);
                 $area->write();
                 $this->owner->$areaID = $area->ID;
+            }else{
+                // ensure correct OwnerClassName
+                $area = ElementalArea::get_by_id($this->owner->$areaID);
+                if( $area->OwnerClassName !== get_class($this->owner) ){
+                    $area->OwnerClassName = get_class($this->owner);
+                    $area->write();
+                }
             }
         }
         return $this->owner;


### PR DESCRIPTION
OwnerClassName in the ElementalArea table can become incorrect in certain scenarios*, and there is currently no way to fix this short of manually editing the database.  An incorrect OwnerClassName breaks the behaviour of BaseElement->getPage(), which breaks all kinds of other things in BaseElement that depend on it.

For example BaseElement->canView() will always return false.  I suspect a lot of people are working around this issue by putting canView{ return true } in all their block types.  That's what we were doing until I decided to really dig into the root cause of why BaseElement->canView() was failing.

This change modifies ElementalAreasExtension->ensureElementalAreasExist(), to verify that the OwnerClassName is correct, and re-saves it with the correct value if it is wrong.

*For example, apply ElementalPageExtension to Page, create a Page, then switch ElementalPageExtension to OtherPage, and switch your created page type to OtherPage.  The OwnerClassName in the DB will still be "Page" and there is no way to fix this currently.