### PR TITLE
FIX Upgrade jQuery to patch vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bootstrap": "^4.3.1",
     "classnames": "^2.2.5",
     "graphql-tag": "^0.1.17",
-    "jquery": "^3.2.1",
+    "jquery": "^3.4.0",
     "prop-types": "^15.6.2",
     "react": "15.3.1",
     "react-addons-test-utils": "15.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4506,9 +4506,10 @@ jest-validate@^19.0.2:
     leven "^2.0.0"
     pretty-format "^19.0.0"
 
-jquery@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
+jquery@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.3.2"


### PR DESCRIPTION
jQuery <3.4.0 contains a vulnerability (CVE-2019-11358)