### PR TITLE
FIX Don't double up on caching efforts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_script:
   # Init PHP
   - phpenv rehash
   - phpenv config-rm xdebug.ini
+  - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
   # Install composer dependencies
   - composer validate

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -21,8 +21,6 @@ use SilverStripe\Versioned\Versioned;
  * @package DNADesign\Elemental\Models
  *
  * @property string $OwnerClassName
- *
- * @method HasManyList|BaseElement[] Elements()
  */
 class ElementalArea extends DataObject
 {
@@ -201,9 +199,10 @@ class ElementalArea extends DataObject
 
             foreach ($elementalAreaRelations as $eaRelationship) {
                 $areaID = $eaRelationship . 'ID';
-
+                
                 $table = DataObject::getSchema()->tableForField($class, $areaID);
-                $page = DataObject::get_one($class, ["\"{$table}\".\"$areaID\" = ?" => $this->ID]);
+                // Opt out of caching as we implement our own caching here
+                $page = DataObject::get_one($class, ["\"{$table}\".\"$areaID\" = ?" => $this->ID], false);
 
                 if ($page) {
                     $this->setOwnerPageCached($page);


### PR DESCRIPTION
Caching in the elemental area is already here and a little more deterministic than on the dataobject level. It's not easy to invalidate the dataobject cache when pages change