### PR TITLE
FIX Allow direct access to set page cache for performance fixes

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -491,6 +491,16 @@ class BaseElement extends DataObject
     }
 
     /**
+     * Set the page in this elements internal cache. This should be used with caution.
+     *
+     * @param DataObject $page
+     */
+    public function setCachePage(DataObject $page)
+    {
+        $this->cacheData['page'] = $page;
+    }
+
+    /**
      * Get a unique anchor name
      *
      * @return string


### PR DESCRIPTION
Pushing the boundaries of "patch" for this "fix". At the moment without #347 there's some relatively inefficient relation querying going on. In custom code that creates lists of blocks we can often set the page ahead of time as we know it. This type of code is a performance fix that this patch enables. Hopefully that's enough :sweat_smile: