### PR TITLE
FIX Drop the TinyMCE toolbar but increase the row count

### DIFF
--- a/src/Forms/EditFormFactory.php
+++ b/src/Forms/EditFormFactory.php
@@ -36,16 +36,18 @@ class EditFormFactory extends DefaultFormFactory
         $fields = parent::getFormFields($controller, $name, $context);
 
         // Configure a slimmed down HTML editor for use with blocks
-        /** @var HTMLEditorField $editorField */
+        /** @var HTMLEditorField|null $editorField */
         $editorField = $fields->fieldByName('Root.Main.HTML');
-        $editorField->setRows(7);
+        if ($editorField) {
+            $editorField->setRows(7);
 
-        $editorConfig = $editorField->getEditorConfig();
+            $editorConfig = $editorField->getEditorConfig();
 
-        // Only configure if the editor is TinyMCE
-        if ($editorConfig instanceof TinyMCEConfig) {
-            $editorConfig->setOption('statusbar', false);
-            $editorField->setEditorConfig($editorConfig);
+            // Only configure if the editor is TinyMCE
+            if ($editorConfig instanceof TinyMCEConfig) {
+                $editorConfig->setOption('statusbar', false);
+                $editorField->setEditorConfig($editorConfig);
+            }
         }
 
         return $fields;

--- a/src/Forms/EditFormFactory.php
+++ b/src/Forms/EditFormFactory.php
@@ -7,6 +7,7 @@ use SilverStripe\Forms\DefaultFormFactory;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
+use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 
 class EditFormFactory extends DefaultFormFactory
 {
@@ -28,6 +29,26 @@ class EditFormFactory extends DefaultFormFactory
         $form->setFields($formFields);
 
         return $form;
+    }
+
+    protected function getFormFields(RequestHandler $controller = null, $name, $context = [])
+    {
+        $fields = parent::getFormFields($controller, $name, $context);
+
+        // Configure a slimmed down HTML editor for use with blocks
+        /** @var HTMLEditorField $editorField */
+        $editorField = $fields->fieldByName('Root.Main.HTML');
+        $editorField->setRows(7);
+
+        $editorConfig = $editorField->getEditorConfig();
+
+        // Only configure if the editor is TinyMCE
+        if ($editorConfig instanceof TinyMCEConfig) {
+            $editorConfig->setOption('statusbar', false);
+            $editorField->setEditorConfig($editorConfig);
+        }
+
+        return $fields;
     }
 
     /**

--- a/src/Forms/EditFormFactory.php
+++ b/src/Forms/EditFormFactory.php
@@ -30,19 +30,6 @@ class EditFormFactory extends DefaultFormFactory
         return $form;
     }
 
-    protected function getFormFields(RequestHandler $controller = null, $name, $context = [])
-    {
-        $fields = parent::getFormFields($controller, $name, $context);
-
-        /** @var HTMLEditorField $contentField */
-        $contentField = $fields->fieldByName('Root.Main.HTML');
-        if ($contentField) {
-            $contentField->setRows(5);
-        }
-
-        return $fields;
-    }
-
     /**
      * Given a {@link FieldList}, give all fields a unique name so they can be used in the same context as
      * other elemental edit forms and the page (or other DataObject) that owns them.

--- a/src/Models/ElementContent.php
+++ b/src/Models/ElementContent.php
@@ -31,21 +31,11 @@ class ElementContent extends BaseElement
     public function getCMSFields()
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
-            // Configure a slimmed down HTML editor for use with blocks
             /** @var HTMLEditorField $editorField */
             $editorField = $fields->fieldByName('Root.Main.HTML');
-            $editorField->setRows(7);
-
-            $editorConfig = $editorField->getEditorConfig();
-
-            // Only configure if the editor is TinyMCE
-            if ($editorConfig instanceof TinyMCEConfig) {
-                $editorConfig->setOption('statusbar', false);
-                $editorField->setEditorConfig($editorConfig);
-            }
-
             $editorField->setTitle(_t(__CLASS__ . '.ContentLabel', 'Content'));
         });
+
         return parent::getCMSFields();
     }
 

--- a/src/Models/ElementContent.php
+++ b/src/Models/ElementContent.php
@@ -3,6 +3,8 @@
 namespace DNADesign\Elemental\Models;
 
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
+use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 use SilverStripe\ORM\FieldType\DBField;
 
 class ElementContent extends BaseElement
@@ -29,9 +31,20 @@ class ElementContent extends BaseElement
     public function getCMSFields()
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
-            $fields
-                ->fieldByName('Root.Main.HTML')
-                ->setTitle(_t(__CLASS__ . '.ContentLabel', 'Content'));
+            // Configure a slimmed down HTML editor for use with blocks
+            /** @var HTMLEditorField $editorField */
+            $editorField = $fields->fieldByName('Root.Main.HTML');
+            $editorField->setRows(7);
+
+            $editorConfig = $editorField->getEditorConfig();
+
+            // Only configure if the editor is TinyMCE
+            if ($editorConfig instanceof TinyMCEConfig) {
+                $editorConfig->setOption('statusbar', false);
+                $editorField->setEditorConfig($editorConfig);
+            }
+
+            $editorField->setTitle(_t(__CLASS__ . '.ContentLabel', 'Content'));
         });
         return parent::getCMSFields();
     }


### PR DESCRIPTION
This fixes an issue where the edit link popover didn't really have room to position itself and would end up appearing off-screen or covering the link you were editing