### PR TITLE
[FIX] Make sure elements in element list get the right ListID

### DIFF
--- a/code/extensions/ElementDuplicationExtension.php
+++ b/code/extensions/ElementDuplicationExtension.php
@@ -20,7 +20,13 @@ class ElementDuplicationExtension extends Extension
                 $items = $original->$relation();
                 foreach ($items as $item) {
                     $duplicateItem = $item->duplicate(false);
-                    $duplicateItem->{$thisClass.'ID'} = $this->owner->ID;
+
+                    if ($this->owner instanceof ElementList) {
+                        $duplicateItem->ListID = $this->owner->ID;
+                    } else {
+                        $duplicateItem->{$thisClass.'ID'} = $this->owner->ID;
+                    }
+
                     $duplicateItem->write();
                 }
             }


### PR DESCRIPTION
The extension restoring the relationships on duplicated elements would expect BaseElement to have a has_one ElementList (and not List) to be able to associate the newly created child elements to the correct list.
This fix explicitly set the ListID value on the duplicates if they belong to an element list. 