### PR TITLE
set $link to null if $page is not present, don't return

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -682,17 +682,17 @@ JS
         $page = $this->getPage();
 
         if (!$page) {
-            return null;
+            $link = null;
         }
 
         if (!$page instanceof SiteTree && method_exists($page, 'CMSEditLink')) {
             $link = Controller::join_links($page->CMSEditLink(), 'ItemEditForm');
-        } else {
+        } elseif ($page) {
             $link = $page->CMSEditLink();
         }
 
         // In-line editable blocks should just take you to the page. Editable ones should add the suffix for detail form
-        if (!$this->inlineEditable() || $directLink) {
+        if ($page && !$this->inlineEditable() || $directLink) {
             $link = Controller::join_links(
                 singleton(CMSPageEditController::class)->Link('EditForm'),
                 $page->ID,


### PR DESCRIPTION
Our site needed to allow some elements (elemental-list) to be created in a ModelAdmin, outside of a page, then be virtualised using silverstripe-elemental-virtual

In order to do this, we needed an extension to be able to use the hook on the BaseElement in the CMSEditLink() function to rewrite the URLS.
The reason for this is that child elements of these lists attempt to find an owning page and navigate to it in order to be edited, but in our case, there is no owning page. Instead, we use the hook to change the URL pattern so the child elements can be edited in the context of their parent element, which is in the ModelAdmin.

The problem is that if a page was not detected, then null was returned, so the hook was never reached.

If the $link is set to null and the following logic takes it into account before trying to use $page, then we can override the CMSEditLink() functionality.

Unsure which branch to target