### PR TITLE
Add config to replace content field

### DIFF
--- a/docs/en/content_migration.md
+++ b/docs/en/content_migration.md
@@ -12,6 +12,26 @@ content for you. It will:
 
 There are several configuration options and extension hooks to allow customising the functionality of this class.
 
+### Choosing not to replace the standard content editor
+
+If you wish to apply elemental to pages but still retain the default `Content` field, use the config setting
+
+```yml
+DNADesign\Elemental\Extensions\ElementalAreasExtension:
+  keep_content_fields: true
+```
+
+**Note** This setting is globally applied. If you wish to replace the default Content area for all but a few
+select page types, you can instead add a config option to that class
+
+```yml
+YourVendor\YourProject\Pages\SpecialBlockAndContentPage:
+  elemental_keep_content_field: true
+```
+
+The owner class config setting will always take precedence over the global setting (on the extension).
+This makes it possible to e.g. keep content fields globally, except for select page types.
+
 ### Configuring the element that is created
 
 You may configure which element content is migrated to by using the following configuration:

--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -72,6 +72,14 @@ class ElementalAreasExtension extends DataExtension
     private static $sort_types_alphabetically = true;
 
     /**
+     * Whether or not to replace the default SiteTree content field
+     *
+     * @var boolean
+     * @config
+     */
+    private static $replace_content_field = true;
+
+    /**
      * Get the available element types for this page type,
      *
      * Uses allowed_elements, stop_element_inheritance, disallowed_elements in
@@ -170,7 +178,9 @@ class ElementalAreasExtension extends DataExtension
 
         // add an empty holder for content as some module explicitly use insert
         // after content.
-        $fields->replaceField('Content', new LiteralField('Content', ''));
+        if (Config::inst()->get(ElementalAreasExtension::class, 'replace_content_field')) {
+            $fields->replaceField('Content', new LiteralField('Content', ''));
+        }
         $elementalAreaRelations = $this->owner->getElementalRelations();
 
         foreach ($elementalAreaRelations as $eaRelationship) {

--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -73,11 +73,13 @@ class ElementalAreasExtension extends DataExtension
 
     /**
      * Whether or not to replace the default SiteTree content field
+     * Applies globally, across all page types; unless a page type overrides this with its own config setting of
+     * `elemental_keep_content_field`
      *
      * @var boolean
      * @config
      */
-    private static $replace_content_field = true;
+    private static $keep_content_fields = false;
 
     /**
      * Get the available element types for this page type,
@@ -176,9 +178,10 @@ class ElementalAreasExtension extends DataExtension
             return;
         }
 
-        // add an empty holder for content as some module explicitly use insert
-        // after content.
-        if (Config::inst()->get(ElementalAreasExtension::class, 'replace_content_field')) {
+        // add an empty holder for content as some module explicitly use insert after content
+        $globalReplace = !Config::inst()->get(self::class, 'keep_content_fields');
+        $classOverride = Config::inst()->get(get_class($this->owner), 'elemental_keep_content_field');
+        if ($globalReplace && !$classOverride || $classOverride === false) {
             $fields->replaceField('Content', new LiteralField('Content', ''));
         }
         $elementalAreaRelations = $this->owner->getElementalRelations();


### PR DESCRIPTION
Add configuration to allow not replacing the 'Content' field to enable backwards compatibility.
This config would allow to use the default content field added in SiteTree and therefore enable a migration from older content blocks modules.

Resolves #410 