### PR TITLE
Allow sortablegridfield dependency in version 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"symbiote/silverstripe-gridfieldextensions": "~2.0",
 		"symbiote/silverstripe-addressable": "~1.0",
 		"heyday/silverstripe-versioneddataobjects": "~2.0",
-		"undefinedoffset/sortablegridfield": "~0.5"
+		"undefinedoffset/sortablegridfield": "~0.5 || ~1.0"
 	},
     "require-dev": {
         "phpunit/PHPUnit": "~3.7@stable"


### PR DESCRIPTION
CWP 1.9.3 requires sortablegridfield in version ~1.0.3, so this tiny update is to accommodate that.