### PR TITLE
Make sure ignored_classes are ignored

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -303,7 +303,19 @@ class ElementalAreasExtension extends DataExtension
             $where[] = $queryDetails . ' IS NULL OR ' . $queryDetails . ' = 0' ;
         }
 
-        foreach ($ownerClass::get()->where(implode(' OR ', $where)) as $elementalObject) {
+        $records = $ownerClass::get()->where(implode(' OR ', $where));
+        if ($ignored_classes = Config::inst()->get(ElementalPageExtension::class, 'ignored_classes')) {
+            $records = $records->exclude('ClassName', $ignored_classes);
+        }
+
+        foreach ($records as $elementalObject) {
+            if ($elementalObject->hasMethod('includeElemental')) {
+                $res = $elementalObject->includeElemental();
+                if ($res === false) {
+                    continue;
+                }
+            }
+
             $needsPublishing = Extensible::has_extension($elementalObject, Versioned::class)
                 && $elementalObject->isPublished();
 


### PR DESCRIPTION
The method requireDefaultRecords does not check on config setting for ignored_classes, nor the extension method 'includeElemental'.

Because all classes are processed each as $ownerClass, subClasses will always also be processed, even when set as ignored.
So ElementalAreas will always be created, even on classes that do not need them.

This can be really problematic on large sites with many pages (ie. shops with 100K products), causing slow or failing dev/build.

This change adds checks to prevent the creation of these unwanted ElementalAreas.