### PR TITLE
Don't redirect to home page on empty CMSEditLink

### DIFF
--- a/templates/DNADesign/Elemental/Models/BaseElement_EditorPreview.ss
+++ b/templates/DNADesign/Elemental/Models/BaseElement_EditorPreview.ss
@@ -1,5 +1,5 @@
 <div class="elemental-preview">
-    <a href="$CMSEditLink" class="elemental-edit">
+    <a <% if $CMSEditLink %>href="$CMSEditLink"<% end_if %> class="elemental-edit">
         <div class="elemental-preview__icon">$Icon</div>
 
         <div class="elemental-preview__detail">


### PR DESCRIPTION
CMSEditLink can sometimes be empty. In this case, clicking on this will take the user out of the CMS and to their site's home page (`<a href="" />`). This took a lot of tracking down. =(