### PR TITLE
BUGFIX: Ensure fields exist before replacing them in readonly transform

### DIFF
--- a/src/Forms/TextCheckboxGroupField.php
+++ b/src/Forms/TextCheckboxGroupField.php
@@ -46,7 +46,7 @@ class TextCheckboxGroupField extends CompositeField
 
             $field->setTemplate(CompositeField::class);
             $field->setTitle('Title');
-            
+
             $titleField = $field->fieldByName('Title');
             if ($titleField) {
                 $field->replaceField('Title', LiteralField::create(

--- a/src/Forms/TextCheckboxGroupField.php
+++ b/src/Forms/TextCheckboxGroupField.php
@@ -46,19 +46,24 @@ class TextCheckboxGroupField extends CompositeField
 
             $field->setTemplate(CompositeField::class);
             $field->setTitle('Title');
-
-            $field->replaceField('Title', LiteralField::create(
-                'Title',
-                $field->fieldByName('Title')->Value()
-            ));
+            
+            $titleField = $field->fieldByName('Title');
+            if ($titleField) {
+                $field->replaceField('Title', LiteralField::create(
+                    'Title',
+                    $titleField->Value()
+                ));
+            }
 
             $displayedText = _t(__CLASS__ . '.DISPLAYED', 'Displayed');
             $notDisplayedText = _t(__CLASS__ . '.NOT_DISPLAYED', 'Not displayed');
-
-            $field->replaceField('ShowTitle', LiteralField::create(
-                'ShowTitle',
-                $field->fieldByName('ShowTitle')->Value() === 'Yes' ? $displayedText : $notDisplayedText
-            )->addExtraClass('show-title'));
+            $showTitle = $field->fieldByName('ShowTitle');
+            if ($showTitle) {
+                $field->replaceField('ShowTitle', LiteralField::create(
+                    'ShowTitle',
+                    $showTitle->Value() === 'Yes' ? $displayedText : $notDisplayedText
+                )->addExtraClass('show-title'));
+            }
         }
 
         return $field;

--- a/tests/Forms/TextCheckboxGroupFieldTest.php
+++ b/tests/Forms/TextCheckboxGroupFieldTest.php
@@ -44,4 +44,12 @@ class TextCheckboxGroupFieldTest extends SapphireTest
             'Uses CompositeField template for readonly'
         );
     }
+
+    public function testRemovedFieldsCanDoReadonlyTransformation()
+    {
+        $this->field->removeByName('Title');
+        $readonly = $this->field->performReadonlyTransformation();
+
+        $this->assertInstanceOf(TextCheckboxGroupField::class, $readonly);
+    }
 }


### PR DESCRIPTION
While the constructor composes the fields in its own specific way, that same composition cannot be relied upon in subsequent method calls. Use cases include removing the checkbox because Title is required and must display.

This change just puts guards around the replace calls to ensure the fields exist.