### PR TITLE
Fix error in non http request environments

### DIFF
--- a/src/Extensions/ElementalPageExtension.php
+++ b/src/Extensions/ElementalPageExtension.php
@@ -57,6 +57,9 @@ class ElementalPageExtension extends ElementalAreasExtension
 
     public function MetaTags(&$tags)
     {
+        if (!Controller::has_curr()) {
+            return;
+        }
         $controller = Controller::curr();
         $request = $controller->getRequest();
         if ($request->getVar('ElementalPreview') !== null) {


### PR DESCRIPTION
Particularly for search indexing we're rendering the page via QueuedJobs, which without this throws the exception:

`PHP Fatal error:  Uncaught Error: Call to a member function getRequest() on null in vendor/dnadesign/silverstripe-elemental/src/Extensions/ElementalPageExtension.php:61`