### PR TITLE
NEW Cache helper methods

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -1033,4 +1033,38 @@ JS
 
         return  ($odd) ? 'odd' : 'even';
     }
+
+    /**
+     * Returns true if the current block state can be cached
+     *
+     * This describes the current block instance state cacheability.
+     *
+     * E.g. if the block is currently rendering a half-filled form with
+     * private user data, it's not cacheable. If the block state is going to
+     * render a simple HTML content, perhaps it may be cached.
+     *
+     * @return bool False by default
+     */
+    public function isCacheable()
+    {
+        return false;
+    }
+
+    /**
+     * Returns the block cache key
+     *
+     * The key should be unique for every instance of the block (per BaseElement->ID).
+     *
+     * It does not have to be unique across different blocks
+     * nor even different instances of the same block.
+     *
+     * If the block is not cacheable {@see self::isCacheable}, this method may
+     * return anything (e.g. non-unique values).
+     *
+     * @return string
+     */
+    public function getCacheKey()
+    {
+        return '';
+    }
 }

--- a/src/Models/ElementContent.php
+++ b/src/Models/ElementContent.php
@@ -55,4 +55,15 @@ class ElementContent extends BaseElement
     {
         return _t(__CLASS__ . '.BlockType', 'Content');
     }
+
+    public function isCacheable()
+    {
+        // check it is not extended by a child class
+        return get_class($this) === self::class;
+    }
+
+    public function getCacheKey()
+    {
+        return hash('sha256', $this->HTML);
+    }
 }

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -297,4 +297,42 @@ class ElementalArea extends DataObject
 
         return false;
     }
+
+    /**
+     * Return cacheability of the current elemental area instance
+     *
+     * This usually means every block in the current area is cacheable.
+     * If a single block is not cacheable, the whole area becomes not cacheable.
+     *
+     * @return bool
+     */
+    public function isCacheable()
+    {
+        foreach($this->Elements() as $element)
+        {
+            if (!$element->isCacheable()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns a unique cache key of the current elemental area instance
+     *
+     * @return string
+     */
+    public function getCacheKey()
+    {
+        $hash = hash_init('sha256');
+        hash_update($hash, $this->ID.$this->LastEdited);
+
+        foreach($this->Elements() as $element)
+        {
+            hash_update($hash, $element->ID.$element->LastEdited);
+            hash_update($hash, $element->getCacheKey());
+        }
+
+        return hash_final($hash);
+    }
 }

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -228,4 +228,21 @@ class BaseElementTest extends FunctionalTest
         $element3->write();
         $this->assertEquals($baselineSort + 2, $element3->Sort, 'Sort order should be higher than the max');
     }
+
+    public function testCacheability()
+    {
+        $baseElement = BaseElement::create(array('Title' => 'Element 1', 'Sort' => 1));
+
+        $this->assertFalse($baseElement->isCacheable(), 'Elements should not be cacheable by default');
+
+        $contentElement = $this->objFromFixture(ElementContent::class, 'content1');
+        $this->assertTrue($contentElement->isCacheable(), 'Elemental content is cacheable');
+
+        $anotherInstance = $this->objFromFixture(ElementContent::class, 'content1');
+        $this->assertEquals(
+            $contentElement->getCacheKey(),
+            $anotherInstance->getCacheKey(),
+            'ElementContent cache keys should match for different instances of the block'
+        );
+    }
 }

--- a/tests/ElementalAreaTest.php
+++ b/tests/ElementalAreaTest.php
@@ -3,6 +3,7 @@
 namespace DNADesign\Elemental\Tests;
 
 use DNADesign\Elemental\Extensions\ElementalPageExtension;
+use DNADesign\Elemental\Models\BaseElement;
 use DNADesign\Elemental\Models\ElementalArea;
 use DNADesign\Elemental\Models\ElementContent;
 use DNADesign\Elemental\Tests\Src\TestElement;
@@ -145,5 +146,22 @@ class ElementalAreaTest extends SapphireTest
         $area->setElementsCached($elements);
 
         $this->assertSame($elements, $area->Elements());
+    }
+
+    public function testCacheability()
+    {
+        $area = ElementalArea::create();
+        $area->Elements()->add(BaseElement::create(['Title' => 'Element 1', 'Sort' => 1]));
+        $area->Elements()->add(ElementContent::create(array('Title' => 'Element 2', 'Sort' => 2, 'HTML' => 'Element 2 Content')));
+        $area->write();
+
+        $this->assertFalse($area->isCacheable(), 'Area containing a BaseElement should not be cacheable');
+
+        $area = ElementalArea::create();
+        $area->Elements()->add(ElementContent::create(['Title' => 'Element 1', 'Sort' => 1, 'HTML' => 'Element 1 Content']));
+        $area->Elements()->add(ElementContent::create(array('Title' => 'Element 2', 'Sort' => 2, 'HTML' => 'Element 2 Content')));
+        $area->write();
+
+        $this->assertTrue($area->isCacheable(), 'Area containing only ElementContent should be cacheable');
     }
 }


### PR DESCRIPTION
A potential implementation of the cache helper methods, accordingly to the discussion in https://github.com/dnadesign/silverstripe-elemental/issues/795

Usage examples

#### Template partial cache
```html
<% cached $ElementalArea.getCacheKey if $ElementalArea.isCacheable %>
    $ElementalArea
<% end_cached %>
```
#### HTTP cache
```php
if (!$elementalArea->isCacheable()) {
    HTTPCacheControlMiddleware::singleton()
        ->disableCache();
}
```