### PR TITLE
FIX Exclude ElementalAreas from file used-on-table

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -10,6 +10,10 @@ SilverStripe\Admin\LeftAndMain:
   extensions:
     - DNADesign\Elemental\Extensions\ElementalLeftAndMainExtension
 
+SilverStripe\Admin\Forms\UsedOnTable:
+  extensions:
+    - DNADesign\Elemental\Extensions\ElementalAreaUsedOnTableExtension
+
 SilverStripe\CMS\Controllers\ContentController:
   extensions:
     - DNADesign\Elemental\Extensions\ElementalContentControllerExtension

--- a/src/Extensions/ElementalAreaUsedOnTableExtension.php
+++ b/src/Extensions/ElementalAreaUsedOnTableExtension.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DNADesign\Elemental\Extensions;
+
+use SilverStripe\Admin\Forms\UsedOnTable;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataObject;
+use DNADesign\Elemental\Models\ElementalArea;
+
+class ElementalAreaUsedOnTableExtension extends DataExtension
+{
+
+    /**
+     * Hides ElementalArea's from the "Used On" tab when viewing files
+     *
+     * @return void
+     * @var ArrayList $dataObjects
+     * @var DataObject $record
+     * @see UsedOnTable::updateUsage
+     */
+    public function updateUsage(ArrayList &$dataObjects, DataObject &$record)
+    {
+        $usage = $dataObjects->exclude('ClassName', ElementalArea::class);
+    }
+}


### PR DESCRIPTION
Tweak for ~https://github.com/silverstripeltd/product-issues/issues/222~ https://github.com/silverstripe/silverstripe-asset-admin/issues/903

Prevent ElementalArea's from showing on the asset-admin file used-on-table

**Before**

![image](https://user-images.githubusercontent.com/4809037/88862771-331fda00-d255-11ea-8ffe-bbddc48d4918.png)

**After**

![image](https://user-images.githubusercontent.com/4809037/88862805-4763d700-d255-11ea-9c60-843bf80f368a.png)
