### PR TITLE
Remove redundant "(displayed if checked)" text from Title field

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -5,7 +5,7 @@ en:
     DISPLAYED: Displayed
     NOT_DISPLAYED: 'Not displayed'
     ShowTitleLabel: Displayed
-    TitleLabel: 'Title (displayed if checked)'
+    TitleLabel: 'Title'
   DNADesign\Elemental\Models\BaseElement:
     BlockType: Block
     CUSTOM_STYLES: 'Select a style..'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -5,7 +5,7 @@ en:
     DISPLAYED: Displayed
     NOT_DISPLAYED: 'Not displayed'
     ShowTitleLabel: Displayed
-    TitleLabel: 'Title'
+    Title: 'Title'
   DNADesign\Elemental\Models\BaseElement:
     BlockType: Block
     CUSTOM_STYLES: 'Select a style..'

--- a/src/Forms/TextCheckboxGroupField.php
+++ b/src/Forms/TextCheckboxGroupField.php
@@ -19,7 +19,7 @@ class TextCheckboxGroupField extends CompositeField
     public function __construct($title = null)
     {
         if (!$title) {
-            $title = _t(__CLASS__ . '.TitleLabel', 'Title (displayed if checked)');
+            $title = _t(__CLASS__ . '.TitleLabel', 'Title');
         }
 
         $fields = [

--- a/src/Forms/TextCheckboxGroupField.php
+++ b/src/Forms/TextCheckboxGroupField.php
@@ -19,7 +19,7 @@ class TextCheckboxGroupField extends CompositeField
     public function __construct($title = null)
     {
         if (!$title) {
-            $title = _t(__CLASS__ . '.TitleLabel', 'Title');
+            $title = _t(__CLASS__ . '.Title', 'Title');
         }
 
         $fields = [

--- a/tests/Behat/features/edit-block-element.feature
+++ b/tests/Behat/features/edit-block-element.feature
@@ -49,7 +49,7 @@ Feature: Edit elements in the CMS
     # The entire block should be clickable to reveal the form
     When I click on block 1
     Then I should see the edit form for block 1
-      And I should see "Title (displayed if checked)"
+      And I should see "Title"
       And the "Content" field should contain "Some content"
       And I fill in "<p>New sample content</p>" for the "Content" HTML field
     When I click on the caret button for block 1

--- a/tests/Behat/features/element-editor.feature
+++ b/tests/Behat/features/element-editor.feature
@@ -32,7 +32,7 @@ Feature: View types of elements in an area on a page
       Then I should see a list of blocks
 
     When I press the "View actions" button
-      Then I should not see "Title (displayed if checked)"
+      Then I should not see "Title"
 
   Scenario: I can see the block type when I hover over an element's icon
     Given I am logged in with "ADMIN" permissions
@@ -54,7 +54,7 @@ Feature: View types of elements in an area on a page
     # The entire block should be clickable to reveal the form
     When I click on block 1
      Then I should see the edit form for block 1
-      And I should see "Title (displayed if checked)"
+      And I should see "Title"
       And the "Content" field should contain "Some content"
       And I fill in "<p>New sample content</p>" for the "Content" HTML field
 


### PR DESCRIPTION
The visible checkbox with the text "Displayed" next to it portrays the same message, so I'd argue adding this wording to the title doesn't provide any value. In fact, I feel it adds clutter to the interface, especially as it maintains the same prominence as the field label, due to it being set in the field title, rather than as help/description text.

**Before:**

![image](https://user-images.githubusercontent.com/329880/89304047-e24d1e80-d664-11ea-8d92-1cfb92f862ae.png)


**After:**

![image](https://user-images.githubusercontent.com/329880/89304076-ec6f1d00-d664-11ea-879a-a942f557f86d.png)
