### PR TITLE
v4: Add an extension point to BaseElement::AbsoluteLink()

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -615,6 +615,8 @@ JS
         if ($page = $this->getPage()) {
             $link = $page->AbsoluteLink($action) . '#' . $this->getAnchor();
 
+            $this->extend('updateAbsoluteLink', $link);
+
             return $link;
         }
 


### PR DESCRIPTION
There is already a similar extension point available in the `Link()` method. Could we please also have this one available in `AbsoluteLink()`?

My current project uses direct routes for Elements (EG: `my-page/my-element`), so we would like to please be able to update both `Link()` and `AbsoluteLink()` appropriately.

Thank you!!