### PR TITLE
DEP Restore GraphQL 4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "silverstripe/admin": "^1.7@dev",
         "silverstripe/versioned": "^1.7@dev",
         "silverstripe/versioned-admin": "^1.7@dev",
-        "silverstripe/graphql": "^3.4",
+        "silverstripe/graphql": "^3.4 || 4.x-dev",
         "symbiote/silverstripe-gridfieldextensions": "^3.1",
         "silverstripe/vendor-plugin": "^1"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "silverstripe/vendor-plugin": "^1"
     },
     "require-dev": {
-      "sminnee/phpunit": "^5.7"
+      "silverstripe/recipe-testing": "1.x-dev"
     },
     "suggest": {
         "silverstripe/elemental-blocks": "Adds a set of common SilverStripe content block types",


### PR DESCRIPTION
This was originally added to the 4 release branch,
and then removed prior to the 4.5.0 release through
https://github.com/dnadesign/silverstripe-elemental/pull/851
to simplify Travis builds.

Explicitly declaring the module *doesn't* support GraphQL 4
is incorrect, and hinders early adoption - you'll need to
run a "silverstripe/graphql:4.x-dev as 3.x-dev" dependency.

It's also a different strategy compared to e.g. versioned-admin:
https://github.com/silverstripe/silverstripe-versioned-admin/commit/cae464fd25494e24d1e05d863c7bc1d4221d8d57