### PR TITLE
Improvement: Add Versioned @mixin and update some linting

### DIFF
--- a/src/Forms/EditFormFactory.php
+++ b/src/Forms/EditFormFactory.php
@@ -6,9 +6,7 @@ use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Forms\DefaultFormFactory;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
-use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 
 class EditFormFactory extends DefaultFormFactory
 {

--- a/src/Forms/ElementalAreaConfig.php
+++ b/src/Forms/ElementalAreaConfig.php
@@ -3,15 +3,8 @@
 namespace DNADesign\Elemental\Forms;
 
 use SilverStripe\Forms\GridField\GridFieldConfig;
-use SilverStripe\Forms\GridField\GridFieldButtonRow;
-use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
-use SilverStripe\Forms\GridField\GridFieldFilterHeader;
-use SilverStripe\Forms\GridField\GridFieldDataColumns;
-use SilverStripe\Forms\GridField\GridFieldEditButton;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\Forms\GridField\GridFieldDetailForm;
-use SilverStripe\Versioned\VersionedGridFieldState\VersionedGridFieldState;
-use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
 class ElementalAreaConfig extends GridFieldConfig
 {

--- a/src/Forms/ElementalAreaField.php
+++ b/src/Forms/ElementalAreaField.php
@@ -2,13 +2,10 @@
 
 namespace DNADesign\Elemental\Forms;
 
-use BlocksPage;
 use DNADesign\Elemental\Controllers\ElementalAreaController;
 use DNADesign\Elemental\Models\BaseElement;
 use DNADesign\Elemental\Models\ElementalArea;
-use DNADesign\Elemental\Services\ElementTabProvider;
 use SilverStripe\Control\Controller;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldGroup;
@@ -221,7 +218,6 @@ class ElementalAreaField extends GridField
 
     public function saveInto(DataObjectInterface $dataObject)
     {
-        /** @var BlocksPage $dataObject */
         parent::saveInto($dataObject);
 
         $elementData = $this->Value();

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -19,8 +19,6 @@ use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
-use SilverStripe\GraphQL\Schema\Schema;
-use SilverStripe\GraphQL\Schema\SchemaBuilder;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBBoolean;
 use SilverStripe\ORM\FieldType\DBField;
@@ -33,7 +31,6 @@ use SilverStripe\VersionedAdmin\Forms\HistoryViewerField;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\Parsers\URLSegmentFilter;
 use SilverStripe\View\Requirements;
-use RuntimeException;
 
 /**
  * Class BaseElement
@@ -47,6 +44,8 @@ use RuntimeException;
  * @property int $ParentID
  *
  * @method ElementalArea Parent()
+ *
+ * @mixin Versioned
  */
 class BaseElement extends DataObject
 {

--- a/src/Models/ElementContent.php
+++ b/src/Models/ElementContent.php
@@ -4,9 +4,11 @@ namespace DNADesign\Elemental\Models;
 
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
-use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 use SilverStripe\ORM\FieldType\DBField;
 
+/**
+ * @property string $HTML
+ */
 class ElementContent extends BaseElement
 {
     private static $icon = 'font-icon-block-content';

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -8,7 +8,6 @@ use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\ArrayList;
-use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
@@ -21,6 +20,8 @@ use SilverStripe\Versioned\Versioned;
  * @package DNADesign\Elemental\Models
  *
  * @property string $OwnerClassName
+ *
+ * @mixin Versioned
  */
 class ElementalArea extends DataObject
 {

--- a/src/Services/ElementTypeRegistry.php
+++ b/src/Services/ElementTypeRegistry.php
@@ -8,7 +8,6 @@ use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 
 class ElementTypeRegistry


### PR DESCRIPTION
* Adding `@mixin Versioned` allows PHPStorm/etc to be aware that these classes have access to the methods/properties within the `Versioned` class.
* Added missing `$HTML` property for `ElementContent`.
* While I was there, I just removed some unused imports.

EG:
![Screen Shot 2021-10-08 at 8 31 04 AM](https://user-images.githubusercontent.com/505788/136454406-3895e4ae-94a2-4923-aee4-0d90d3aa5844.png)

