### PR TITLE
FIX Use correct return type for permission checks

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -217,7 +217,7 @@ class BaseElement extends DataObject implements CMSPreviewable
             }
         }
 
-        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
+        return Permission::check('CMS_ACCESS', 'any', $member);
     }
 
     /**
@@ -240,7 +240,7 @@ class BaseElement extends DataObject implements CMSPreviewable
             }
         }
 
-        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
+        return Permission::check('CMS_ACCESS', 'any', $member);
     }
 
     /**
@@ -272,7 +272,7 @@ class BaseElement extends DataObject implements CMSPreviewable
             }
         }
 
-        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
+        return Permission::check('CMS_ACCESS', 'any', $member);
     }
 
     /**
@@ -290,7 +290,7 @@ class BaseElement extends DataObject implements CMSPreviewable
             return $extended;
         }
 
-        return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
+        return Permission::check('CMS_ACCESS', 'any', $member);
     }
 
     public function write($showDebug = false, $forceInsert = false, $forceWrite = false, $writeComponents = false)


### PR DESCRIPTION
Revival of https://github.com/silverstripe/silverstripe-elemental/pull/951 - this time against the new major branch to address the BC concerns raised in comments on that PR.

As per https://github.com/silverstripe/silverstripe-framework/issues/10184 it is established that the return type for `canX` methods on a `DataObject` should be boolean - `null` is not a valid return type from these methods.

## Parent issue
- fixes https://github.com/silverstripe/silverstripe-elemental/issues/1003