### PR TITLE
FIX Cast possibly null link to string

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -374,9 +374,9 @@ class BaseElement extends DataObject implements CMSPreviewable
                 ->setTitle(_t(__CLASS__ . '.MainTabLabel', 'Content'));
 
             $fields->addFieldsToTab('Root.Main', [
-                HiddenField::create('AbsoluteLink', false, Director::absoluteURL($this->PreviewLink())),
-                HiddenField::create('LiveLink', false, Director::absoluteURL($this->Link())),
-                HiddenField::create('StageLink', false, Director::absoluteURL($this->PreviewLink())),
+                HiddenField::create('AbsoluteLink', false, Director::absoluteURL((string) $this->PreviewLink())),
+                HiddenField::create('LiveLink', false, Director::absoluteURL((string) $this->Link())),
+                HiddenField::create('StageLink', false, Director::absoluteURL((string) $this->PreviewLink())),
             ]);
 
             $styles = $this->config()->get('styles');
@@ -384,7 +384,7 @@ class BaseElement extends DataObject implements CMSPreviewable
             if ($styles && count($styles ?? []) > 0) {
                 $styleDropdown = DropdownField::create('Style', _t(__CLASS__.'.STYLE', 'Style variation'), $styles);
 
-                $fields->insertBefore($styleDropdown, 'ExtraClass');
+                $fields->insertBefore('ExtraClass', $styleDropdown);
 
                 $styleDropdown->setEmptyString(_t(__CLASS__.'.CUSTOM_STYLES', 'Select a style..'));
             } else {
@@ -937,7 +937,7 @@ JS
      */
     public function getEditLink()
     {
-        return Director::absoluteURL($this->CMSEditLink());
+        return Director::absoluteURL((string) $this->CMSEditLink());
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/642

Fixes

`ERROR [Emergency]: Uncaught TypeError: SilverStripe\Control\Director::absoluteURL(): Argument #1 ($url) must be of type string, null given, called in /home/runner/work/silverstripe-graphql/silverstripe-graphql/vendor/dnadesign/silverstripe-elemental/src/Models/BaseElement.php on line 940`
https://github.com/silverstripe/silverstripe-graphql/actions/runs/3645001687/jobs/6154761063#step:10:1226

Exception happens during `dev/build` - [api change](https://github.com/silverstripe/silverstripe-framework/commit/53c0147f112a011f8cbdfb964a92dc4eb81a8b7f#diff-983f05f9a107b9bf66a1ed4230e524be82118dd71f4a795529f8794b762c8b47R408) on `Director::absoluteUrl()` means null is no longer accepted
