### PR TITLE
MNT Broken builds

### DIFF
--- a/src/TopPage/DataExtension.php
+++ b/src/TopPage/DataExtension.php
@@ -4,7 +4,7 @@ namespace DNADesign\Elemental\TopPage;
 
 use DNADesign\Elemental\Models\BaseElement;
 use DNADesign\Elemental\Models\ElementalArea;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\ORM\DataExtension as BaseDataExtension;
 use SilverStripe\ORM\DataObject;
@@ -20,7 +20,7 @@ use SilverStripe\View\ViewableData;
  * with deeply nested block structures. Apply to @see BaseElement and @see ElementalArea.
  *
  * @property int $TopPageID
- * @method Page TopPage()
+ * @method SiteTree TopPage()
  * @property BaseElement|ElementalArea|$this $owner
  * @package DNADesign\Elemental\TopPage
  */
@@ -31,7 +31,7 @@ class DataExtension extends BaseDataExtension
      * @var array
      */
     private static $has_one = [
-        'TopPage' => Page::class,
+        'TopPage' => SiteTree::class,
     ];
 
     /**
@@ -78,13 +78,13 @@ class DataExtension extends BaseDataExtension
     }
 
     /**
-     * Finds the top-level Page object for a Block / ElementalArea, using the cached TopPageID
+     * Finds the top-level SiteTree object for a Block / ElementalArea, using the cached TopPageID
      * reference when possible.
      *
-     * @return Page|null
+     * @return SiteTree|null
      * @throws ValidationException
      */
-    public function getTopPage(): ?Page
+    public function getTopPage(): ?SiteTree
     {
         $list = [$this->owner];
 
@@ -96,7 +96,7 @@ class DataExtension extends BaseDataExtension
                 continue;
             }
 
-            if ($item instanceof Page) {
+            if ($item instanceof SiteTree) {
                 // trivial case
                 return $item;
             }
@@ -142,10 +142,10 @@ class DataExtension extends BaseDataExtension
      * automatic page determination will be attempted
      * Note that this may not always succeed as your model may not be attached to parent object at the time of this call
      *
-     * @param Page|null $page
+     * @param SiteTree|null $page
      * @throws ValidationException
      */
-    public function setTopPage(?Page $page = null): void
+    public function setTopPage(?SiteTree $page = null): void
     {
         /** @var BaseElement|ElementalArea|Versioned|DataExtension $owner */
         $owner = $this->owner;
@@ -224,9 +224,9 @@ class DataExtension extends BaseDataExtension
     /**
      * Assigns top page relation
      *
-     * @param Page $page
+     * @param SiteTree $page
      */
-    protected function assignTopPage(Page $page): void
+    protected function assignTopPage(SiteTree $page): void
     {
         $this->owner->TopPageID = (int) $page->ID;
     }
@@ -295,11 +295,11 @@ class DataExtension extends BaseDataExtension
      * features on top of existing ones not replacing them
      *
      * @param int $id
-     * @return Page|null
+     * @return SiteTree|null
      */
-    protected function getTopPageFromCachedData(int $id): ?Page
+    protected function getTopPageFromCachedData(int $id): ?SiteTree
     {
-        $page = Page::get_by_id($id);
+        $page = SiteTree::get_by_id($id);
 
         if (!$page || !$page->exists()) {
             return null;

--- a/src/TopPage/FluentExtension.php
+++ b/src/TopPage/FluentExtension.php
@@ -4,7 +4,7 @@ namespace DNADesign\Elemental\TopPage;
 
 use DNADesign\Elemental\Models\BaseElement;
 use DNADesign\Elemental\Models\ElementalArea;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Queries\SQLUpdate;
 use TractorCow\Fluent\State\FluentState;
@@ -31,7 +31,7 @@ class FluentExtension extends DataExtension
     /*
      * @inheritdoc
      */
-    protected function assignTopPage(Page $page): void
+    protected function assignTopPage(SiteTree $page): void
     {
         parent::assignTopPage($page);
 

--- a/src/TopPage/SiteTreeExtension.php
+++ b/src/TopPage/SiteTreeExtension.php
@@ -4,7 +4,7 @@ namespace DNADesign\Elemental\TopPage;
 
 use DNADesign\Elemental\Extensions\ElementalPageExtension;
 use DNADesign\Elemental\Models\ElementalArea;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Model\SiteTreeExtension as BaseSiteTreeExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
@@ -15,7 +15,7 @@ use SilverStripe\ORM\ValidationException;
  * This extension must be present on pagetypes that need to support Elemental TopPage functionality.
  * It can be applied directly to Page, as it only takes effect in the presence of a ElementalArea.
  *
- * @property Page|$this $owner
+ * @property SiteTree|$this $owner
  * @package DNADesign\Elemental\TopPage
  */
 class SiteTreeExtension extends BaseSiteTreeExtension
@@ -48,9 +48,9 @@ class SiteTreeExtension extends BaseSiteTreeExtension
     /**
      * Extension point in @see DataObject::duplicate()
      *
-     * @param Page $original
+     * @param SiteTree $original
      */
-    public function onBeforeDuplicate(Page $original): void
+    public function onBeforeDuplicate(SiteTree $original): void
     {
         $this->initDuplication($original);
     }
@@ -58,11 +58,11 @@ class SiteTreeExtension extends BaseSiteTreeExtension
     /**
      * Extension point in @see DataObject::duplicate()
      *
-     * @param Page $original
+     * @param SiteTree $original
      * @param bool $doWrite
      * @throws ValidationException
      */
-    public function onAfterDuplicate(Page $original, $doWrite): void
+    public function onAfterDuplicate(SiteTree $original, $doWrite): void
     {
         $this->processDuplication($original, (bool) $doWrite);
     }
@@ -131,9 +131,9 @@ class SiteTreeExtension extends BaseSiteTreeExtension
     }
 
     /**
-     * @param Page|SiteTreeExtension $original
+     * @param SiteTree|SiteTreeExtension $original
      */
-    protected function initDuplication(Page $original): void
+    protected function initDuplication(SiteTree $original): void
     {
         $key = $original->getDuplicationKey();
 
@@ -152,11 +152,11 @@ class SiteTreeExtension extends BaseSiteTreeExtension
     /**
      * Update top page reference during duplication process
      *
-     * @param Page $original
+     * @param SiteTree $original
      * @param bool $written
      * @throws ValidationException
      */
-    protected function processDuplication(Page $original, bool $written): void
+    protected function processDuplication(SiteTree $original, bool $written): void
     {
         if ($written) {
             $this->writeDuplication($original);
@@ -177,7 +177,7 @@ class SiteTreeExtension extends BaseSiteTreeExtension
      */
     protected function processDuplicationFromOriginal(): void
     {
-        /** @var Page|ElementalPageExtension $owner */
+        /** @var SiteTree|ElementalPageExtension $owner */
         $owner = $this->owner;
 
         if (!isset($owner->duplicationOriginal)) {
@@ -186,7 +186,7 @@ class SiteTreeExtension extends BaseSiteTreeExtension
 
         $original = $owner->duplicationOriginal;
 
-        if (!$original instanceof Page) {
+        if (!$original instanceof SiteTree) {
             return;
         }
 
@@ -195,10 +195,10 @@ class SiteTreeExtension extends BaseSiteTreeExtension
     }
 
     /**
-     * @param Page|SiteTreeExtension $original
+     * @param SiteTree|SiteTreeExtension $original
      * @throws ValidationException
      */
-    protected function writeDuplication(Page $original): void
+    protected function writeDuplication(SiteTree $original): void
     {
         $key = $original->getDuplicationKey();
         $currentKey = $this->getDuplicatedPageKey();
@@ -230,7 +230,7 @@ class SiteTreeExtension extends BaseSiteTreeExtension
      */
     protected function setTopPageForElementalArea(): void
     {
-        /** @var Page|ElementalPageExtension $owner */
+        /** @var SiteTree|ElementalPageExtension $owner */
         $owner = $this->owner;
 
         if (!$owner->hasExtension(ElementalPageExtension::class)) {

--- a/tests/GraphQL/FakeResolveInfo.php
+++ b/tests/GraphQL/FakeResolveInfo.php
@@ -2,6 +2,7 @@
 
 namespace DNADesign\Elemental\Tests\GraphQL;
 
+use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\ObjectType;
@@ -12,20 +13,15 @@ class FakeResolveInfo extends ResolveInfo
 {
     public function __construct()
     {
-        // webonyx/graphql-php v0.12
-        if (!property_exists(__CLASS__, 'fieldDefinition')) {
-            return;
-        }
-        // webonyx/graphql-php v14
         parent::__construct(
-            FieldDefinition::create(['name' => 'fake', 'type' => Type::string()]),
-            [],
+            new FieldDefinition(['name' => 'fake', 'type' => Type::string()]),
+            new \ArrayObject(),
             new ObjectType(['name' => 'fake']),
             [],
             new Schema([]),
             [],
             '',
-            null,
+            new OperationDefinitionNode([]),
             []
         );
     }


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/659

Fixes:
- `Error: Call to undefined method GraphQL\Type\Definition\FieldDefinition::create()`
- `TypeError: DNADesign\Elemental\TopPage\SiteTreeExtension::onBeforeDuplicate(): Argument https://github.com/silverstripeltd/product-issues/issues/1 ($original) must be of type Page, SilverStripe\CMS\Model\SiteTree given`

The Page/SiteTree type error only occurs in recipe-kitchen-sink, not installer. I'm not sure why this is, though I don't there's any downsite to loosening the Page type the more standard SiteTree class which is allowed since this is for a new major version

The endtoend tests are failing because the elemental editor in the page edit form is not rendering at all - there are the following javascript errors which I'm going to assume are going to be fixed in [this issue](https://github.com/silverstripeltd/product-issues/issues/644)
![image](https://user-images.githubusercontent.com/4809037/213382603-423d4868-bd5a-4170-8050-8b6d0695e464.png)

