### PR TITLE
MNT Broken builds

### DIFF
--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -405,7 +405,7 @@ class BaseElementTest extends FunctionalTest
             'element1' => [
                 ElementContent::class,
                 'content1',
-                '/test-elemental/#e1',
+                '/test-elemental#e1',
             ],
             // Element in DataObject
             'element2' => [
@@ -443,7 +443,7 @@ class BaseElementTest extends FunctionalTest
             [
                 ElementContent::class,
                 'content1',
-                '/test-elemental/',
+                '/test-elemental',
             ],
             // Element in DataObject WITHOUT PreviewLink or Link
             [


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/659

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/3990680546/jobs/6844618517#step:12:68
` 1) DNADesign\Elemental\Tests\BaseElementTest::testLinkWithDataObject with data set "element1" ('DNADesign\Elemental\Models\El...ontent', 'content1', '/test-elemental/#e1') Failed asserting that two strings are equal.`

Broken behat tests + js job will be fixed as part of https://github.com/silverstripeltd/product-issues/issues/644