### PR TITLE
FIX Respect existing query strings and anchors in preview link

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -779,7 +779,7 @@ JS
             if ($link) {
                 // The ElementalPreview getvar is used in ElementalPageExtension
                 // The anchor must be at the end of the URL to function correctly
-                $link .= '?ElementalPreview=' . mt_rand() . '#' . $this->getAnchor();
+                $link = Controller::join_links($link, '?ElementalPreview=' . mt_rand() . '#' . $this->getAnchor());
             }
         }
 

--- a/tests/ElementalAreaDataObjectTest.yml
+++ b/tests/ElementalAreaDataObjectTest.yml
@@ -11,6 +11,9 @@ DNADesign\Elemental\Models\ElementalArea:
   areaDataObject4:
     Title: Area 4
     OwnerClassName: DNADesign\Elemental\Tests\Src\TestPreviewableDataObjectWithLink
+  areaDataObject5:
+    Title: Area 5
+    OwnerClassName: DNADesign\Elemental\Tests\Src\TestPreviewableDataObjectWithLink
 
 DNADesign\Elemental\Tests\Src\TestDataObjectWithCMSEditLink:
   dataObject1:
@@ -31,6 +34,10 @@ DNADesign\Elemental\Tests\Src\TestPreviewableDataObjectWithLink:
   dataObject4:
     Title: DataObject with PreviewLink and Link methods
     ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject4
+  dataObject5:
+    Title: DataObject with PreviewLink with querystring and anchor
+    LinkData: 'base-link?something=value&somethingelse=value2#some-anchor'
+    ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject5
 
 DNADesign\Elemental\Tests\Src\TestElement:
   elementDataObject1:
@@ -49,6 +56,10 @@ DNADesign\Elemental\Tests\Src\TestElement:
     Title: Element 4
     TestValue: 'Hello Test'
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject4
+  elementDataObject5:
+    Title: Element 5
+    TestValue: 'Hello Test'
+    ParentID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject5
 
 DNADesign\Elemental\Tests\Src\TestElementDataObject:
   testElementDataObject1:

--- a/tests/Src/TestPreviewableDataObjectWithLink.php
+++ b/tests/Src/TestPreviewableDataObjectWithLink.php
@@ -8,8 +8,16 @@ class TestPreviewableDataObjectWithLink extends TestPreviewableDataObject implem
 {
     private static $table_name = 'TestPreviewableDataObjectWithLink';
 
+    private static $db = [
+        'LinkData' => 'Varchar(255)',
+    ];
+
+    private static $defaults = [
+        'LinkData' => 'base-link',
+    ];
+
     public function Link($action = null)
     {
-        return 'base-link';
+        return $this->LinkData;
     }
 }


### PR DESCRIPTION
If the object owning the block has its own query string and/or anchor in the preview URL, it causes problems (see issue)

## parent issue
- https://github.com/silverstripe/silverstripe-elemental/issues/1038