### PR TITLE
ENH Include summary in elemental area by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ An element is as simple as a PHP class which extends `DNADesign\Elemental\Models
 with it (unless you want it to use the default template). After you add the class, ensure you have rebuilt your
 database and reload the CMS.
 
+The `getSummary()` method will be used to provide a short summary to content authors of what data is in the element.
+
 ```php
 <?php
 
@@ -179,6 +181,11 @@ class MyElement extends BaseElement
         // ...
 
         return $fields;
+    }
+
+    public function getSummary(): string
+    {
+        return /* some string that represents the data in this element */;
     }
 
     public function getType()

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -965,8 +965,9 @@ JS
     }
 
     /**
-     * This can be overridden on child elements to create a summary for display
-     * in GridFields.
+     * This can be overridden on child elements to create a summary for display in GridFields.
+     * The react Summary component takes `content` (html) and/or `fileUrl` & `fileTitle` (image) props,
+     * which have to be added to the graphql output in `provideBlockSchema()`.
      *
      * @return string
      */
@@ -1023,6 +1024,7 @@ JS
             'actions' => [
                 'edit' => $this->getEditLink(),
             ],
+            'content' => $this->getSummary(),
         ];
     }
 

--- a/src/Models/ElementContent.php
+++ b/src/Models/ElementContent.php
@@ -46,13 +46,6 @@ class ElementContent extends BaseElement
         return DBField::create_field('HTMLText', $this->HTML)->Summary(20);
     }
 
-    protected function provideBlockSchema()
-    {
-        $blockSchema = parent::provideBlockSchema();
-        $blockSchema['content'] = $this->getSummary();
-        return $blockSchema;
-    }
-
     public function getType()
     {
         return _t(__CLASS__ . '.BlockType', 'Content');


### PR DESCRIPTION
Backporting to `5.0` - this is a breaking change so we need to make sure it's included in the initial release.
ref https://github.com/silverstripe/silverstripe-elemental/pull/948