### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/cms": "4.13.x-dev",
-        "silverstripe/admin": "1.13.x-dev",
-        "silverstripe/versioned": "1.13.x-dev",
-        "silverstripe/versioned-admin": "1.13.x-dev",
-        "silverstripe/graphql": "3.8.x-dev || 4.2.x-dev",
+        "silverstripe/framework": "^4.12@dev",
+        "silverstripe/cms": "^4.7@dev",
+        "silverstripe/admin": "^1.7@dev",
+        "silverstripe/versioned": "^1.7@dev",
+        "silverstripe/versioned-admin": "^1.7@dev",
+        "silverstripe/graphql": "^3.5 || ^4",
         "symbiote/silverstripe-gridfieldextensions": "^3.1",
         "silverstripe/vendor-plugin": "^1"
     },


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

See https://github.com/silverstripe/silverstripe-elemental/commit/c50d13013a1dd5df8be8c5aa06daea332994457e

## Issue
- https://github.com/silverstripe/.github/issues/33