### PR TITLE
ENH Optimise site search

### DIFF
--- a/docs/en/searching-blocks.md
+++ b/docs/en/searching-blocks.md
@@ -40,3 +40,33 @@ to make it clear in search results where one piece of content ends and another b
 Page:
   search_index_element_delimiter: ' ... '
 ```
+
+## CMS page search
+
+CMS page search will include search results for pages with elements that match the search query.
+
+By default it uses the same method as the search indexing where it will fully render every element that is
+being searched. This is an expensive operation and can cause performance issues if you have a large site with a lot of elements.
+
+To increase performance by a large amount, likely more than doubling it, you can disable the rendering of elements and instead just look at the database values of the elements directly.
+
+```yml
+DNADesign\Elemental\Controllers\ElementSiteTreeFilterSearch:
+  render_elements: false
+```
+
+If `render_elements` is `false`, then all fields that have stored as a Varchar or Text like are searched. Individual fields on blocks can be excluded from the search by adding fields to the `exclude_fields_from_cms_search` array config variable on the element class. e.g.
+
+```yml
+App\MyElement:
+  fields_excluded_from_cms_search:
+    - MyFieldToExclude
+    - AnotherFieldToExclude
+```
+
+If the above is still not performant enough, searching elements for content in CMS page search can be disabled entirely:
+
+```yml
+DNADesign\Elemental\Controllers\ElementSiteTreeFilterSearch:
+  search_for_term_in_content: false
+```

--- a/src/Controllers/ElementSiteTreeFilterSearch.php
+++ b/src/Controllers/ElementSiteTreeFilterSearch.php
@@ -21,6 +21,11 @@ class ElementSiteTreeFilterSearch extends CMSSiteTreeFilter_Search
     private static $search_for_term_in_content = true;
 
     /**
+     * Whether to render elements with templates when doing a CMS SiteTree search
+     */
+    private static bool $render_elements = true;
+
+    /**
      * @var array
      */
     private $extraTermFilters = [];
@@ -47,8 +52,13 @@ class ElementSiteTreeFilterSearch extends CMSSiteTreeFilter_Search
                 return false;
             }
 
-            // Check whether the search term exists in the nested page content
-            $pageContent = $siteTree->getElementsForSearch();
+            if ($this->config()->get('render_elements') === true) {
+                // Check whether the search term exists in the nested page content
+                $pageContent = $siteTree->getElementsForSearch();
+            } else {
+                $pageContent = $siteTree->getContentFromElementsForCmsSearch();
+            }
+
             return stripos($pageContent ?? '', $this->params['Term'] ?? '') !== false;
         });
 

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -495,4 +495,12 @@ class BaseElementTest extends FunctionalTest
             $this->assertSame($link, $previewLink);
         }
     }
+
+    public function testGetContentForCmsSearch()
+    {
+        $element = $this->objFromFixture(ElementContent::class, 'content1');
+        $this->assertSame('Test Content', $element->getContentForCmsSearch());
+        $element = $this->objFromFixture(TestElement::class, 'elementDataObject3');
+        $this->assertSame('Hello Test|#|Element 3', $element->getContentForCmsSearch());
+    }
 }

--- a/tests/Controllers/ElementSiteTreeFilterSearchTest.php
+++ b/tests/Controllers/ElementSiteTreeFilterSearchTest.php
@@ -6,6 +6,13 @@ use DNADesign\Elemental\Extensions\ElementalPageExtension;
 use DNADesign\Elemental\Tests\Src\TestPage;
 use SilverStripe\CMS\Controllers\CMSSiteTreeFilter_Search;
 use SilverStripe\Dev\SapphireTest;
+use DNADesign\Elemental\Controllers\ElementSiteTreeFilterSearch;
+use ReflectionMethod;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\ORM\DataObjectSchema;
+use DNADesign\Elemental\Models\ElementContent;
+use DNADesign\Elemental\Tests\Src\TestElementContentExtension;
 
 class ElementSiteTreeFilterSearchTest extends SapphireTest
 {
@@ -15,6 +22,9 @@ class ElementSiteTreeFilterSearchTest extends SapphireTest
         TestPage::class => [
             ElementalPageExtension::class,
         ],
+        ElementContent::class => [
+            TestElementContentExtension::class,
+        ]
     ];
 
     protected static $extra_dataobjects = [
@@ -50,6 +60,78 @@ class ElementSiteTreeFilterSearchTest extends SapphireTest
                 ['Title' => 'Content blocks page'],
                 ['Title' => 'Regular page'],
             ]],
+        ];
+    }
+
+    /**
+     * @dataProvider provideApplyDefaultFilters
+     */
+    public function testApplyDefaultFilters(bool $renderElements, string $term, array $expected): void
+    {
+        // Set protected method visibility - applyDefaultFilters() is essentially an
+        // extension method that's called by silverstripe/cms, so use of reflection here
+        // is pretty much required
+        $method = new ReflectionMethod(ElementSiteTreeFilterSearch::class, 'applyDefaultFilters');
+        Config::modify()->set(ElementSiteTreeFilterSearch::class, 'render_elements', $renderElements);
+        $filterSearch = new ElementSiteTreeFilterSearch(['Term' => $term]);
+        $ret = $method->invoke($filterSearch, DataObject::get(TestPage::class));
+        $this->assertSame($expected, $ret->column('Title'));
+    }
+
+    public function provideApplyDefaultFilters(): array
+    {
+
+        return [
+            'render_elements true - text search' => [
+                'render_elements' => true,
+                'term' => 'This content is rendered',
+                'expected' => ['Content blocks page']
+            ],
+            'render_elements true - unrendered search' => [
+                'render_elements' => true,
+                'term' => 'This field is unrendered',
+                'expected' => []
+            ],
+            'render_elements true - extended search' => [
+                'render_elements' => true,
+                'term' => 'This content is from an extension hook',
+                'expected' => []
+            ],
+            'render_elements true - int search' => [
+                'render_elements' => true,
+                'term' => '456',
+                'expected' => []
+            ],
+            'render_elements true - enum search' => [
+                'render_elements' => true,
+                'term' => 'Sunny',
+                'expected' => []
+            ],
+            'render_elements false - text search' => [
+                'render_elements' => false,
+                'term' => 'This content is rendered',
+                'expected' => ['Content blocks page']
+            ],
+            'render_elements false - unrendered search' => [
+                'render_elements' => false,
+                'term' => 'This field is unrendered',
+                'expected' => ['Content blocks page']
+            ],
+            'render_elements false - extended search' => [
+                'render_elements' => false,
+                'term' => 'This content is from an extension hook',
+                'expected' => ['Content blocks page']
+            ],
+            'render_elements false - int search' => [
+                'render_elements' => false,
+                'term' => '456',
+                'expected' => []
+            ],
+            'render_elements false - enum search' => [
+                'render_elements' => false,
+                'term' => 'Sunny',
+                'expected' => []
+            ],
         ];
     }
 }

--- a/tests/Controllers/ElementSiteTreeFilterSearchTest.yml
+++ b/tests/Controllers/ElementSiteTreeFilterSearchTest.yml
@@ -17,3 +17,12 @@ DNADesign\Elemental\Models\ElementContent:
     Title: Content
     HTML: Specifically blocks page content
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.blocks_page_area
+    MyInt: 123
+    MyEnum: Cloudy
+  blocks_page_unrendered_content:
+    Title: My title
+    HTML: This content is rendered
+    ParentID: =>DNADesign\Elemental\Models\ElementalArea.blocks_page_area
+    UnrenderedField: This field is unrendered
+    MyInt: 456
+    MyEnum: Sunny

--- a/tests/Src/TestElementContentExtension.php
+++ b/tests/Src/TestElementContentExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DNADesign\Elemental\Tests\Src;
+
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\Dev\TestOnly;
+
+class TestElementContentExtension extends DataExtension implements TestOnly
+{
+    private static $db = [
+        'UnrenderedField' => 'Varchar(255)',
+        'MyInt' => 'Int',
+        'MyEnum' => 'Enum("Sunny, Cloudy", "Sunny")'
+    ];
+
+    public function updateContentForCmsSearch(array &$contents)
+    {
+        $contents[] = 'This content is from an extension hook';
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-elemental/issues/1067

There's a couple of bits to this PR:

A) Utilise eager loading - this gives a small performance gain of ~9%

B) Don't render elemental templates, instead only look at database values on the element (won't include any child DataObjects) - this gave a large performance gain, over 100% improvement

There's likely going to be a "loss in accuracy" (though may also be a gain) in exchange for the massive performance boost - the change in accuracy is a result of:
- more content being searched across, because now fields not on the rendered template will be searched against
- less content being searched across, because any child objects on the element that are normally rendered won't be search against

We'd also need to agree whether to make this an opt-in or an opt-out.  In this PR I've got it as the more conservative opt-in, though I'd prefer opt-out as most people will likely not even realise it's an option available, and I given it's "only" cms page search I don't think any possible loss in accuracy really warrants the fact that page search really is horrible slow without this optimization (I've had people tell me about 10 second response times, and even sites timing out).

Options:
- 1) opt-in in CMS 5.1, stays as opt-in for CMS 6
- 2) opt-in in CMS 5.1, change to opt-out for CMS 6
- 3) opt-out in CMS 5.1 (my recommendation)

### Benchmarks

Running a CMS search for "lorem" against 1,000 pages with 5 blocks each (total of 5,000 blocks) - data generated with https://github.com/emteknetnz/silverstripe-test-data - total of 3 runs - times are in seconds

**render elements - eager load off - (current) - avg 5.81**
5.92
5.63
5.87

**render elements - eager load on - avg 5.35**
5.35
5.21
5.50

**unrendered - eager load off - avg 2.36**
2.37
2.35
2.36

**unrendered - eager load on - avg 2.15**
2.09
2.24
2.13
