### PR TITLE
fix: getPage returning the wrong page

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -692,21 +692,28 @@ JS
 
     /**
      * Despite the name of the method, getPage can return any type of DataObject
+     *
      * @return null|DataObject
      * @throws \Psr\Container\NotFoundExceptionInterface
      * @throws \SilverStripe\ORM\ValidationException
      */
     public function getPage()
     {
-        // Allow for repeated calls to be cached
         if (isset($this->cacheData['page'])) {
-            return $this->cacheData['page'];
+            if (isset($this->cacheData['parent_id']) && $this->cacheData['parent_id'] === $this->ParentID) {
+                return $this->cacheData['page'];
+            }
         }
 
         $class = DataObject::getSchema()->hasOneComponent($this, 'Parent');
         $area = ($this->ParentID) ? DataObject::get_by_id($class, $this->ParentID) : null;
+
         if ($area instanceof ElementalArea && $area->exists()) {
-            $this->cacheData['page'] = $area->getOwnerPage();
+            $page = $area->getOwnerPage();
+
+            $this->cacheData['page'] = $page;
+            $this->cacheData['parent_id'] = $this->ParentID;
+
             return $this->cacheData['page'];
         }
 

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -511,4 +511,17 @@ class BaseElementTest extends FunctionalTest
         $element = $this->objFromFixture(TestElement::class, 'elementDataObject3');
         $this->assertSame('Hello Test|#|Element 3', $element->getContentForCmsSearch());
     }
+
+
+    public function testGetPage()
+    {
+        $element = $this->objFromFixture(ElementContent::class, 'content1');
+
+        $this->assertStringContainsString($element->getPage()->Title, 'Test Elemental');
+
+        $newArea = $this->objFromFixture(ElementalArea::class, 'area52');
+        $element->ParentID = $newArea->ID;
+
+        $this->assertStringContainsString($element->getPage()->Title, 'Page with one elements');
+    }
 }


### PR DESCRIPTION
If you programaticaly update the ParentID of an element, getPage() still returns the outdated page.