### PR TITLE
FIX Apply multiupload auto-detection for upload fields

### DIFF
--- a/src/Forms/EditFormFactory.php
+++ b/src/Forms/EditFormFactory.php
@@ -2,6 +2,7 @@
 
 namespace DNADesign\Elemental\Forms;
 
+use SilverStripe\AssetAdmin\Forms\UploadField;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Forms\DefaultFormFactory;
@@ -66,6 +67,10 @@ class EditFormFactory extends DefaultFormFactory
         $elementID = $context['Record']->ID;
 
         foreach ($fields->dataFields() as $field) {
+            if ($field instanceof UploadField) {
+                // Apply audo-detection of multi-upload before changing the name.
+                $field->setIsMultiUpload($field->getIsMultiUpload());
+            }
             $namespacedName = sprintf(self::FIELD_NAMESPACE_TEMPLATE ?? '', $elementID, $field->getName());
             $field->setName($namespacedName);
         }


### PR DESCRIPTION
UploadField checks hasone components based on the field name to see if it can be a multiUpload field or not. We need to trigger that before changing the name of the field.

## Issue
- https://github.com/silverstripe/silverstripe-elemental/issues/1104