### PR TITLE
PATCH: removing superfluous (and breaking) Controller::join_links

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -851,7 +851,7 @@ JS
             if ($link) {
                 // The ElementalPreview getvar is used in ElementalPageExtension
                 // The anchor must be at the end of the URL to function correctly
-                $link = Controller::join_links($link, '?ElementalPreview=' . mt_rand() . '#' . $this->getAnchor());
+                $link .= '?ElementalPreview=' . mt_rand() . '#' . $this->getAnchor();
             }
         }
 


### PR DESCRIPTION
The Controller::join_links function removed the ? in the Preview Link.