### PR TITLE
ENH BaseElement::getType() use static::class instead of __CLASS__ for…

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -441,7 +441,7 @@ JS
     {
         $default = $this->i18n_singular_name() ?: 'Block';
 
-        return _t(__CLASS__ . '.BlockType', $default);
+        return _t(static::class . '.BlockType', $default);
     }
 
     /**


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

Without this then the default is always the singular name of `BaseElement` ('Block'). This allows each subclass to have a more sensible default based on `$singular_name`.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-elemental/issues/831

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green