### PR TITLE
FIX Do not publish dataobject in requireDefaultRecords()

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -15,6 +15,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\RelatedData\StandardRelatedDataService;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\ViewableData;
 
@@ -328,15 +329,9 @@ class ElementalAreasExtension extends DataExtension
                 }
             }
 
-            $needsPublishing = ViewableData::has_extension($elementalObject, Versioned::class)
-                && $elementalObject->isPublished();
-
             /** @var ElementalAreasExtension $elementalObject */
             $elementalObject->ensureElementalAreasExist($elementalAreas);
             $elementalObject->write();
-            if ($needsPublishing) {
-                $elementalObject->publishRecursive();
-            }
         }
 
         $this->owner->extend('onAfterRequireDefaultElementalRecords');

--- a/tests/Src/TestVersionedDataObject.php
+++ b/tests/Src/TestVersionedDataObject.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace DNADesign\Elemental\Tests\Src;
+
+use DNADesign\Elemental\Models\ElementalArea;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Versioned\Versioned;
+
+class TestVersionedDataObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'TestVersionedDataObject';
+
+    private static $extensions = [
+        Versioned::class,
+    ];
+
+    private static $db = [
+        'Title' => 'Varchar(255)',
+    ];
+
+    private static $has_one = [
+        'ElementalArea' => ElementalArea::class,
+    ];
+
+    private static $owns = [
+        'ElementalArea',
+    ];
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-elemental/issues/1130

As far as I can tell there's absolutely no reason to publish the Page/DataObject at this point.  I think the intention was originally to ensure that any owned ElementalAreas would be published ... however they'll just get published when you publish the page/dataobject

I even tested the following succesfully:
- Remove the elemental extension, dev/build flush
- Create a blocks page, publish
- Edit page content, save without publish
- Enable elemental extension, dev/build flush
- Create an elemental and inline publish it (note this will mistakenly indicate the page publish button has published, however refreshing the page will show the correct state i.e. page is modified)

There are no network or console warnings when doing this, database records have the correct IDs etc
