### PR TITLE
fix: correct preview view when using subsites

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -553,7 +553,7 @@ JS
         }
         // Allow projects to update contents of third-party elements.
         $this->extend('updateContentForCmsSearch', $contents);
-        
+
         // Use |#| to delimit different fields rather than space so that you don't
         // accidentally join results of two columns that are next to each other in a table
         $content = implode('|#|', array_filter($contents));
@@ -841,12 +841,14 @@ JS
     {
         $link = null;
         if ($page = $this->getPage()) {
-            if (ClassInfo::hasMethod($page, 'Link')) {
-                $link = $page->Link($action);
-            }
-            if (!$link && ($page instanceof CMSPreviewable)) {
+            if ($page instanceof CMSPreviewable) {
                 $link = $page->PreviewLink($action);
             }
+
+            if (!$link && ClassInfo::hasMethod($page, 'Link')) {
+                $link = $page->Link($action);
+            }
+
             if ($link) {
                 // The ElementalPreview getvar is used in ElementalPageExtension
                 // The anchor must be at the end of the URL to function correctly

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -445,7 +445,7 @@ class BaseElementTest extends FunctionalTest
             [
                 ElementContent::class,
                 'content1',
-                '/test-elemental',
+                'test-elemental',
             ],
             // Element in DataObject WITHOUT PreviewLink or Link
             [
@@ -492,8 +492,9 @@ class BaseElementTest extends FunctionalTest
             // Note that the preview link is suffixed with forward slash when subsites is installed
             // because of BaseElementSubsites::updatePreviewLink() use of HTTP::setGetVar()
             // which turns relative urls to absolute urls
-            $regex = '/^\/?' . preg_quote($link, '/') . '[?&]' . preg_quote('ElementalPreview=', '/')
+            $regex = '/' . preg_quote($link, '/') . '[?&]' . preg_quote('ElementalPreview=', '/')
                 .'\d*#' . $element->getAnchor() . '$/';
+
             $this->assertMatchesRegularExpression($regex, $previewLink);
             // Doesn't try to blindly append query string and anchor - but instead merges intelligently with
             // whatever's already there

--- a/tests/Src/TestPreviewableDataObjectWithLink.php
+++ b/tests/Src/TestPreviewableDataObjectWithLink.php
@@ -16,6 +16,11 @@ class TestPreviewableDataObjectWithLink extends TestPreviewableDataObject implem
         'LinkData' => 'base-link',
     ];
 
+    public function PreviewLink($action = null)
+    {
+        return null;
+    }
+
     public function Link($action = null)
     {
         return $this->LinkData;


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Preference should be given to the page CMSPreviewLink so to align to the functionality on the main view. Link() should be as a fallback if PreviewLink() is not defined on the parent object.
## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

This will manifest itself in a few ways the the easiest way to reproduce is 

* When using subsites and editing a subsite from the main site domain (i.e *.cwp.govt.nz) 
* The block is non-inline editable

The calculated preview link would be /page/url which will display the main site 404.

Expected behaviour is it matches the pages PreviewLink (with the relevant `SubsiteID` argument present).

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-elemental/issues/1182

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green