### PR TITLE
FIX Provide instance of CompositeField rather than class string

### DIFF
--- a/src/Forms/ElementalAreaField.php
+++ b/src/Forms/ElementalAreaField.php
@@ -184,7 +184,7 @@ class ElementalAreaField extends GridField
     public function performReadonlyTransformation()
     {
         /** @var CompositeField $readOnlyField */
-        $readOnlyField = $this->castedCopy(CompositeField::class);
+        $readOnlyField = $this->castedCopy(CompositeField::create());
         $blockReducer = $this->getReadOnlyBlockReducer();
         $readOnlyField->setChildren(
             FieldList::create(array_map($blockReducer, $this->getArea()->Elements()->toArray() ?? []))


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11198

Fixes unit test failing in kitchen-sink ci run on recipe-content-blocks

```
1) DNADesign\Elemental\Tests\Forms\ElementalAreaFieldTest::testFieldReturnsCompositeFieldOnReadonlyTransformation
TypeError: get_class(): Argument #1 ($object) must be of type object, string given

/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/framework/src/Forms/FieldList.php:49
/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/framework/src/Forms/CompositeField.php:63
/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/InjectionCreator.php:35
/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/Injector.php:631
/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/Injector.php:1027
/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/Injector.php:979
/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/Injector.php:1152
/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/Injectable.php:30
/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/framework/src/Forms/FormField.php:1365
/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/dnadesign/silverstripe-elemental/src/Forms/ElementalAreaField.php:187
/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/dnadesign/silverstripe-elemental/tests/Forms/ElementalAreaFieldTest.php:41
/home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/bin/phpunit:122
```