### PR TITLE
DEP Bump framework dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.1",
         "silverstripe/cms": "^5",
         "silverstripe/admin": "^2.0.1",
         "silverstripe/versioned": "^2",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-elemental/issues/1192

I had a look through the [diff between 5.0 and 5](https://github.com/silverstripe/silverstripe-elemental/compare/5.0...5) and I think the new eager loading API framework was the only thing that was missed

Note that it's basically too late to fix this on 5.2 and below.  We could fix this on elemental 5.2.2, however all that will do is cause composer to install 5.2.1 if you're on framwork 5.0.x which won't actually fix the missing eager loading API, so I think for the sake of less confusion it's better to just target this at elemental 5.3.0

