### PR TITLE
API Deprecate BaseElement::getDescription()

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -34,6 +34,7 @@ use SilverStripe\View\Parsers\URLSegmentFilter;
 use SilverStripe\View\Requirements;
 use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\DataObjectSchema;
 
 /**
@@ -553,7 +554,7 @@ JS
         }
         // Allow projects to update contents of third-party elements.
         $this->extend('updateContentForCmsSearch', $contents);
-        
+
         // Use |#| to delimit different fields rather than space so that you don't
         // accidentally join results of two columns that are next to each other in a table
         $content = implode('|#|', array_filter($contents));
@@ -1142,10 +1143,13 @@ JS
     /**
      * Get a description for this content element, if available
      *
+     * @deprecated 5.3.0 Use the description configuration property and localisation API directly instead.
+     *
      * @return string
      */
     public function getDescription()
     {
+        Deprecation::notice('5.3.0', 'Use getTypeNice() or the description configuration property directly instead.');
         $description = $this->config()->uninherited('description');
         if ($description) {
             return _t(__CLASS__ . '.Description', $description);
@@ -1161,7 +1165,7 @@ JS
      */
     public function getTypeNice()
     {
-        $description = $this->getDescription();
+        $description = Deprecation::withNoReplacement(fn () => $this->getDescription());
         $desc = ($description) ? ' <span class="element__note"> &mdash; ' . $description . '</span>' : '';
 
         return DBField::create_field(


### PR DESCRIPTION
Replaces https://github.com/silverstripe/silverstripe-elemental/pull/953

This will free up `Description` to be used as a db column for blocks.
I had considered replacing `getDescription()` with `geti18nDescription()` to keep a method where the localised description could be fetched - but it seems unlikely that there are use cases to want to fetch that information directly outside of its use in the react components.

## Issue
- https://github.com/silverstripe/silverstripe-elemental/issues/1106