### PR TITLE
DEP Bump framework dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.1",
         "silverstripe/cms": "^5",
         "silverstripe/admin": "^2.0.1",
         "silverstripe/versioned": "^2",


### PR DESCRIPTION
Backport cherry-pick of https://github.com/silverstripe/silverstripe-elemental/pull/1193

We've decided to release this in 5.2 so as to fix the broken --prefer-lowest build