### PR TITLE
DEP Bump framework dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5.1",
+        "silverstripe/framework": "^5.2",
         "silverstripe/cms": "^5",
         "silverstripe/admin": "^2.0.1",
         "silverstripe/versioned": "^2",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Fixes

 1) DNADesign\Elemental\Tests\Controllers\ElementalAreaControllerTest::testElementFormGetSchema with data set "Valid existing record" ('', 200)
Error: Class "SilverStripe\Forms\SearchableDropdownField" not found

https://github.com/silverstripe/silverstripe-elemental/actions/runs/9854774231/job/27208281967