### PR TITLE
DEP Update minimum dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.2",
         "silverstripe/cms": "^5",
         "silverstripe/admin": "^2.0.1",
         "silverstripe/versioned": "^2",


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-elemental/actions/runs/10031428259/job/27721872095

> BadMethodCallException: Object->__call(): the method 'eagerLoad' does not exist on 'SilverStripe\ORM\DataList'

and

> Error: Class "SilverStripe\Forms\SearchableDropdownField" not found

`eagerLoad()` was added in `silverstripe/framework` 5.1, but `SearchableDropdownField` was added in 5.2 so we need at least that version.

## Issues
- https://github.com/silverstripe/.github/issues/285