### PR TITLE
Added `$startIndex` param to `Pos` method

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -1261,11 +1261,12 @@ JS
     /**
      * Returns the position of the current element.
      *
+     * @param int $startIndex Number to start count from.
      * @return int
      */
-    public function Pos()
+    public function Pos($startIndex = 1)
     {
-        return ($this->Parent()->Elements()->filter('Sort:LessThan', $this->Sort)->count() + 1);
+        return ($this->Parent()->Elements()->filter('Sort:LessThan', $this->Sort)->count() + $startIndex);
     }
 
     /**


### PR DESCRIPTION
## Description
I've added `$startIndex` param to the `Pos` method with a default value of `1`.

## Manual testing steps
Loop through elements in an elemental area and print the results of `$Pos(1)`.

## Issues
- #1221

## Pull request checklist
- [X] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [X] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [X] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [X] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [X] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
