### PR TITLE
FIX Use canDelete, not the now-deleted canArchive

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -276,11 +276,7 @@ class BaseElement extends DataObject implements CMSPreviewable
 
         if ($this->hasMethod('getPage')) {
             if ($page = $this->getPage()) {
-                if ($page->hasExtension(Versioned::class)) {
-                    return Deprecation::withNoReplacement(fn() => $page->canArchive($member));
-                } else {
-                    return $page->canDelete($member);
-                }
+                return $page->canDelete($member);
             }
         }
 


### PR DESCRIPTION
`canArchive()` is removed in favour of `canDelete()` in https://github.com/silverstripe/silverstripe-versioned/pull/460

## Issue
- https://github.com/silverstripe/silverstripe-versioned/issues/447