### PR TITLE
ENH Don't emit deprecation warnings for unavoidable API calls

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -277,7 +277,7 @@ class BaseElement extends DataObject implements CMSPreviewable
         if ($this->hasMethod('getPage')) {
             if ($page = $this->getPage()) {
                 if ($page->hasExtension(Versioned::class)) {
-                    return $page->canArchive($member);
+                    return Deprecation::withNoReplacement(fn() => $page->canArchive($member));
                 } else {
                     return $page->canDelete($member);
                 }


### PR DESCRIPTION
`Versioned::canArchive()` is deprecated in https://github.com/silverstripe/silverstripe-versioned/pull/461

We can't stop calling it directly until CMS 6 because people may have implemented extensions that update the result of this permission check.

## Issue
- https://github.com/silverstripe/silverstripe-versioned/issues/447