### PR TITLE
MNT Temporarily add Deprecation class

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -37,6 +37,7 @@ use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * Class BaseElement


### PR DESCRIPTION
The Deprecation class was somehow missed from being included merge-up

Have used an MNT prefix because we'll be removing the deprecated cos pretty shortly, though we just need this here for now so that elemental is installable