### PR TITLE
API Remove custom logic in favour of Form::saveInto()

### DIFF
--- a/src/Controllers/ElementalAreaController.php
+++ b/src/Controllers/ElementalAreaController.php
@@ -298,8 +298,7 @@ class ElementalAreaController extends CMSMain
     }
 
     /**
-     * Arrive here from FormRequestHandler::httpSubmission() during a POST request to
-     * /admin/linkfield/linkForm/<LinkID>
+     * Arrive here from FormRequestHandler::httpSubmission() during a POST request.
      * The 'save' method is called because it is the FormAction set on the Form
      */
     public function save(array $data, Form $form): HTTPResponse
@@ -331,13 +330,15 @@ class ElementalAreaController extends CMSMain
             $this->jsonError(403);
         }
 
-        // Remove the namespace prefixes that were added by EditFormFactory
-        $dataWithoutNamespaces = static::removeNamespacesFromFields($data, $element->ID);
+        // Remove the namespace prefixes
+        $factory = Injector::inst()->get(EditFormFactory::class);
+        $factory->removeNamespaceFromFields($form->Fields(), ['Record' => $element]);
+        // Update the record
+        $form->saveInto($element);
+        // Add the namespace prefixes back - this is necessary for the response to be handled correctly
+        $factory->namespaceFields($form->Fields(), ['Record' => $element]);
 
-        // Update and write the data object which will trigger model validation.
-        // Would usually be handled by $form->saveInto($element) but since the field names
-        // in the form have been namespaced, we need to handle it ourselves.
-        $element->updateFromFormData($dataWithoutNamespaces);
+        // Write the data object which will trigger model validation
         if ($element->isChanged()) {
             try {
                 $element->write();
@@ -352,31 +353,6 @@ class ElementalAreaController extends CMSMain
         $response = $this->getSchemaResponse($schemaID, $form);
 
         return $response;
-    }
-
-    /**
-     * Remove the pseudo namespaces that were added to form fields by the form factory
-     *
-     * @param array $data
-     * @param int $elementID
-     * @return array
-     * @deprecated 5.4.0 Will be removed without equivalent functionality to replace it.
-     */
-    public static function removeNamespacesFromFields(array $data, $elementID)
-    {
-        Deprecation::noticeWithNoReplacment('5.4.0');
-        $output = [];
-        $template = sprintf(EditFormFactory::FIELD_NAMESPACE_TEMPLATE, $elementID, '');
-        foreach ($data as $key => $value) {
-            // Only look at fields that match the namespace template
-            if (substr($key ?? '', 0, strlen($template ?? '')) !== $template) {
-                continue;
-            }
-
-            $fieldName = substr($key ?? '', strlen($template ?? ''));
-            $output[$fieldName] = $value;
-        }
-        return $output;
     }
 
     private function reorderElements(BaseElement $element, int $afterElementID): void

--- a/src/Forms/EditFormFactory.php
+++ b/src/Forms/EditFormFactory.php
@@ -86,11 +86,8 @@ class EditFormFactory extends DefaultFormFactory
     /**
      * Given a {@link FieldList}, give all fields a unique name so they can be used in the same context as
      * other elemental edit forms and the page (or other DataObject) that owns them.
-     *
-     * @param FieldList $fields
-     * @param array $context
      */
-    protected function namespaceFields(FieldList $fields, array $context)
+    public function namespaceFields(FieldList $fields, array $context): void
     {
         $elementID = $context['Record']->ID;
 
@@ -101,6 +98,24 @@ class EditFormFactory extends DefaultFormFactory
             }
             $namespacedName = sprintf(EditFormFactory::FIELD_NAMESPACE_TEMPLATE ?? '', $elementID, $field->getName());
             $field->setName($namespacedName);
+        }
+    }
+
+    /**
+     * Remove the pseudo namespaces that were added in namespaceFields()
+     */
+    public function removeNamespaceFromFields(FieldList $fields, array $context): void
+    {
+        $elementID = $context['Record']->ID;
+        $template = sprintf(EditFormFactory::FIELD_NAMESPACE_TEMPLATE, $elementID, '');
+
+        foreach ($fields->dataFields() as $namespacedName => $field) {
+            // Only look at fields that match the namespace template
+            if (substr($namespacedName, 0, strlen($template)) !== $template) {
+                continue;
+            }
+            $newName = substr($namespacedName, strlen($template));
+            $field->setName($newName);
         }
     }
 }

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -647,23 +647,6 @@ JS
     }
 
     /**
-     * Given form data (wit
-     *
-     * @param $data
-     * @deprecated 5.4.0 Will be removed without equivalent functionality to replace it.
-     */
-    public function updateFromFormData($data)
-    {
-        Deprecation::noticeWithNoReplacment('5.4.0');
-        $cmsFields = $this->getCMSFields()->saveableFields();
-        foreach ($cmsFields as $fieldName => $field) {
-            $datum = $data[$fieldName] ?? null;
-            $field->setSubmittedValue($datum);
-            $field->saveInto($this);
-        }
-    }
-
-    /**
      * Strip all namespaces from class namespace.
      *
      * @param string $classname e.g. "\Fully\Namespaced\Class"

--- a/tests/Forms/EditFormFactoryTest.php
+++ b/tests/Forms/EditFormFactoryTest.php
@@ -4,7 +4,11 @@ namespace DNADesign\Elemental\Tests\Forms;
 
 use DNADesign\Elemental\Forms\EditFormFactory;
 use DNADesign\Elemental\Models\ElementContent;
+use SilverStripe\AssetAdmin\Forms\UploadField;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\TextField;
 
 class EditFormFactoryTest extends SapphireTest
 {
@@ -12,7 +16,6 @@ class EditFormFactoryTest extends SapphireTest
 
     public function testFormFieldsHaveNamespaces()
     {
-        /** @var ElementContent $record */
         $record = $this->objFromFixture(ElementContent::class, 'content_block');
 
         $factory = new EditFormFactory();
@@ -20,5 +23,43 @@ class EditFormFactoryTest extends SapphireTest
         $fields = $result->Fields();
 
         $this->assertNotNull($fields->dataFieldByName('PageElements_' . $record->ID . '_Title'));
+    }
+
+    public function testNamespaceFields(): void
+    {
+        $record = $this->objFromFixture(ElementContent::class, 'content_block');
+        $factory = new EditFormFactory();
+        $fields = new FieldList([
+            new TextField('FieldOne'),
+            new LiteralField('IgnoredField', ''),
+            new UploadField('FieldTwo'),
+        ]);
+        $factory->namespaceFields($fields, ['Record' => $record]);
+
+        $expectedNames = [
+            'PageElements_' . $record->ID . '_FieldOne',
+            'IgnoredField',
+            'PageElements_' . $record->ID . '_FieldTwo',
+        ];
+        $this->assertSame($expectedNames, $fields->column('Name'));
+    }
+
+    public function testRemoveNamespaceFromFields(): void
+    {
+        $record = $this->objFromFixture(ElementContent::class, 'content_block');
+        $factory = new EditFormFactory();
+        $fields = new FieldList([
+            new TextField('PageElements_' . $record->ID . '_FieldOne'),
+            new LiteralField('IgnoredField', ''),
+            new UploadField('PageElements_' . $record->ID . '_FieldTwo'),
+        ]);
+        $factory->removeNamespaceFromFields($fields, ['Record' => $record]);
+
+        $expectedNames = [
+            'FieldOne',
+            'IgnoredField',
+            'FieldTwo',
+        ];
+        $this->assertSame($expectedNames, $fields->column('Name'));
     }
 }


### PR DESCRIPTION
I don't think this warrants a note in the changelog beyond what will be automatically generated for the removed API - though feel free to disagree and if so I'll add a docs PR.

## Issue
- https://github.com/silverstripe/silverstripe-elemental/issues/1268