### PR TITLE
API Make ElementalAreaController a subclass of FormSchemaController

### DIFF
--- a/src/Controllers/ElementalAreaController.php
+++ b/src/Controllers/ElementalAreaController.php
@@ -5,7 +5,6 @@ namespace DNADesign\Elemental\Controllers;
 use DNADesign\Elemental\Forms\EditFormFactory;
 use DNADesign\Elemental\Models\BaseElement;
 use DNADesign\Elemental\Services\ElementTypeRegistry;
-use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\Form;
@@ -20,17 +19,18 @@ use DNADesign\Elemental\Services\ReorderElements;
 use Exception;
 use SilverStripe\Control\HTTPRequest;
 use InvalidArgumentException;
+use SilverStripe\Admin\FormSchemaController;
 
 /**
  * Controller for "ElementalArea" - handles loading and saving of in-line edit forms in an elemental area in admin
  */
-class ElementalAreaController extends CMSMain
+class ElementalAreaController extends FormSchemaController
 {
     const FORM_NAME_TEMPLATE = 'ElementForm_%s';
 
     private static $url_segment = 'elemental-area';
 
-    private static $ignore_menuitem = true;
+    private static string $required_permission_codes = 'CMS_ACCESS';
 
     private static $url_handlers = [
         'elementForm/$ItemID' => 'elementForm',

--- a/tests/Controllers/ElementalAreaControllerTest.php
+++ b/tests/Controllers/ElementalAreaControllerTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 class ElementalAreaControllerTest extends FunctionalTest
 {
     protected static $fixture_file = 'ElementalAreaControllerTest.yml';
-    
+
     protected static $extra_dataobjects = [
         TestElementContent::class,
         TestElementalArea::class,
@@ -180,9 +180,9 @@ class ElementalAreaControllerTest extends FunctionalTest
         $response = $this->post($url, $data, $headers);
         $this->assertSame($expectedCode, $response->getStatusCode());
         if ($fail === 'csrf-token') {
-            // Will end up at an HTML page with "Silverstripe - Bad Request"
-            $this->assertSame('text/html; charset=utf-8', $response->getHeader('Content-type'));
-            $this->assertStringContainsString('Silverstripe - Bad Request', $response->getBody());
+            // Gives suitable error message for XHR request
+            $this->assertStringStartsWith('text/plain', $response->getHeader('Content-type'));
+            $this->assertStringContainsString('There seems to have been a technical problem', $response->getBody());
             return;
         }
         $this->assertSame($expectedCode, $response->getStatusCode());


### PR DESCRIPTION
Needs https://github.com/silverstripe/silverstripe-admin/pull/1850 for CI to go green. Please merge that first.

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1762