### PR TITLE
Add IsFirst/IsLast methods to match SS5 conventions (closes #1274)

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -1232,19 +1232,39 @@ JS
     }
 
     /**
-     * @return boolean
+     * Returns true if this is the first element rendered in the ElementalArea
+     * @return bool
      */
-    public function First()
+    public function IsFirst(): bool
     {
         return ($this->Parent()->Elements()->first()->ID === $this->ID);
     }
 
     /**
-     * @return boolean
+     * @deprecated 5.4.0 Use IsFirst() instead.
+     */
+    public function First()
+    {
+        Deprecation::notice('5.4.0', 'Use IsFirst() instead');
+        return $this->IsFirst();
+    }
+
+    /**
+     * Returns true if this is the last element rendered in the ElementalArea
+     * @return bool
+     */
+    public function IsLast(): bool
+    {
+        return ($this->Parent()->Elements()->last()->ID === $this->ID);
+    }
+
+    /**
+     * @deprecated 5.4.0 Use IsLast() instead.
      */
     public function Last()
     {
-        return ($this->Parent()->Elements()->last()->ID === $this->ID);
+        Deprecation::notice('5.4.0', 'Use IsLast() instead');
+        return $this->IsLast();
     }
 
     /**

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -190,6 +190,15 @@ class BaseElementTest extends FunctionalTest
         $this->assertEquals('', $element->getStyleVariant());
     }
 
+    public function testIsFirst()
+    {
+        $element = $this->objFromFixture(ElementContent::class, 'content1');
+        $element2 = $this->objFromFixture(ElementContent::class, 'content2');
+
+        $this->assertTrue($element->IsFirst());
+        $this->assertFalse($element2->IsFirst());
+    }
+
     public function testFirst()
     {
         $element = $this->objFromFixture(ElementContent::class, 'content1');
@@ -197,6 +206,15 @@ class BaseElementTest extends FunctionalTest
 
         $this->assertTrue($element->First());
         $this->assertFalse($element2->First());
+    }
+
+    public function testIsLast()
+    {
+        $element = $this->objFromFixture(ElementContent::class, 'content1');
+        $element2 = $this->objFromFixture(ElementContent::class, 'content2');
+
+        $this->assertFalse($element->Last());
+        $this->assertTrue($element2->Last());
     }
 
     public function testLast()


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Deprecates `First()` and `Last()` in favour of `IsFirst()` and `IsLast()`, as these methods are intended to override the built-in iteration methods of those names.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
Check the value of `$IsFirst` and `$IsLast` in elemental block templates

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #1274 

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
