### PR TITLE
FIX: Allow for custom admin url

### DIFF
--- a/src/Controllers/ElementalAreaController.php
+++ b/src/Controllers/ElementalAreaController.php
@@ -5,6 +5,7 @@ namespace DNADesign\Elemental\Controllers;
 use DNADesign\Elemental\Forms\EditFormFactory;
 use DNADesign\Elemental\Models\BaseElement;
 use DNADesign\Elemental\Services\ElementTypeRegistry;
+use SilverStripe\Admin\AdminRootController;
 use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
@@ -240,7 +241,7 @@ class ElementalAreaController extends CMSMain
         );
 
         $urlSegment = $this->config()->get('url_segment');
-        $form->setFormAction("admin/$urlSegment/elementForm/$id");
+        $form->setFormAction(AdminRootController::admin_url("$urlSegment/elementForm/$id"));
 
         if (!$element->canEdit()) {
             $form->makeReadonly();


### PR DESCRIPTION
## Description
Allow inline editable content blocks to be saved when using a [custom admin route](https://docs.silverstripe.org/en/5/developer_guides/customising_the_admin_interface/cms_architecture/#the-admin-url).

## Manual testing steps
* Set a [custom admin route](https://docs.silverstripe.org/en/5/developer_guides/customising_the_admin_interface/cms_architecture/#the-admin-url).
* Add a Content Block to an element area.
* Make changes to the content block and try to save it.
* Verify that changes are saved successfully.

## Issues
- #1281

## Pull request checklist
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [x] The commit messages follow our [commit message guidelines]
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
