### PR TITLE
DEP Don't include vendor-plugin as an explicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "silverstripe/admin": "^3",
         "silverstripe/versioned": "^3",
         "silverstripe/versioned-admin": "^3",
-        "symbiote/silverstripe-gridfieldextensions": "^5",
-        "silverstripe/vendor-plugin": "^2"
+        "symbiote/silverstripe-gridfieldextensions": "^5"
     },
     "require-dev": {
         "silverstripe/documentation-lint": "^1",


### PR DESCRIPTION
We don't directly reference it in code or config, so we can rely on silverstripe/framework having this dependency for us.

## Issue
- https://github.com/silverstripe/.github/issues/311