### PR TITLE
DEP Require framework ^5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5.2",
+        "silverstripe/framework": "^5.3",
         "silverstripe/cms": "^5",
         "silverstripe/admin": "^2.0.1",
         "silverstripe/versioned": "^2",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/357

Fixes https://github.com/silverstripe/silverstripe-graphql/actions/runs/12640442927/job/35285220759 which broke because was using framwork 5.2 instead of 5.3 because this line was different - [5.2](https://github.com/silverstripe/silverstripe-framework/blob/5.2/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php#L173) - [5.3](https://github.com/silverstripe/silverstripe-framework/blob/5.3/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php#L174)

This PR is a little unusual because there's nothing in elemental 5.3 that strictly requires API in framework 5.3, it's just that requiring a later version of framework is the only way I can think of fixing this.  It may make more a little clearer to keep the ^5.2 framework contraint and add a conflict for framework < 5.3 instead, let me know if you would prefer that and I'll update the PR.

Broken tests were:
```
    vendor/dnadesign/silverstripe-elemental/tests/Behat/features/add-block-element-to-data-object.feature:11
    vendor/dnadesign/silverstripe-elemental/tests/Behat/features/edit-block-element.feature:80
    vendor/dnadesign/silverstripe-elemental/tests/Behat/features/inline-block-validation.feature:57
    vendor/dnadesign/silverstripe-elemental/tests/Behat/features/non-page-save-validation.feature:18
    vendor/dnadesign/silverstripe-elemental/tests/Behat/features/page-save-validation.feature:19
    vendor/dnadesign/silverstripe-elemental/tests/Behat/features/versioned-status-block-element.feature:17
```