### PR TITLE
FIX Call property directly to prevent infinite recursion

### DIFF
--- a/src/Forms/TextCheckboxGroupField.php
+++ b/src/Forms/TextCheckboxGroupField.php
@@ -63,8 +63,7 @@ class TextCheckboxGroupField extends CompositeField
 
     public function getMessageCast()
     {
-        $message = parent::getMessage();
-        if ($message) {
+        if ($this->message) {
             return parent::getMessageCast();
         }
         foreach ($this->getChildren() as $field) {


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/357

Fixes issue where framework FormMessage::getMessage() and elemental TextCheckboxGroupField::getMessageCast() end up in an infinite loop e.g. https://github.com/silverstripe/silverstripe-elemental/actions/runs/12761071213/job/35617198112 though also happens in quite a few other places

Can be triggered by add-block-element-to-data-object.feature:11