### PR TITLE
Reports print view - escaped html bug

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -1162,7 +1162,7 @@ JS
     public function getTypeNice()
     {
         $description = Deprecation::withSuppressedNotice(fn () => $this->getDescription());
-        $desc = ($description) ? ' <span class="element__note"> &mdash; ' . $description . '</span>' : '';
+        $desc = $description ? " <span class=\"element__note\"> — {$description}</span>" : '';
 
         return DBField::create_field(
             'HTMLVarchar',


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Print Report view was double-escaping the mdash, showing the escaped html "&mdash;" instead of "—"
<img width="517" alt="Screenshot 2025-02-04 at 11 10 20 AM" src="https://github.com/user-attachments/assets/60f9ff8d-dd1b-4a7e-9ef8-5434b56d99de" />

This fix replaces the escaped character with the character itself.

I've also removed the redundant brackets and interpolated the string, because I can't help myself.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

1. In the CMS, navigate to Reports
2. Select a report
3. Click Print button

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/11596

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
