### PR TITLE
ENH: better anchors from blocks => provide human readable value

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -771,7 +771,11 @@ JS
      */
     public function getAnchorsInContent(): array
     {
-        $anchors = [$this->getAnchor()];
+        $anchors = [
+            $this->getAnchor() => 
+            ($this->Title ?: _t(__CLASS__ . '.NoTitleSet', '[NO TITLE SET]') . 
+            ' (' . $this->getType() . '#' . $this->ID . ')'
+        ];
         $anchorRegex = "/\\s+(name|id)\\s*=\\s*([\"'])([^\\2\\s>]*?)\\2|\\s+(name|id)\\s*=\\s*([^\"']+)[\\s +>]/im";
         $allFields = DataObject::getSchema()->fieldSpecs($this);
         foreach ($allFields as $field => $fieldSpec) {


### PR DESCRIPTION




## Description

Right now, when you get a list of anchors from an elemental, the first anchor will be something like: ['e1123' => 'e1123']
This does not make any sense for the user.

This is the first step in correcting this by changing it to  ['e1123] => 'Title of block goes here']

## Manual testing steps

- This is only the first step towards having better anchors. This provides better anchors, after we may need to change other modules to make it work. However, in the project I tried it, it already worked straight away!

## Issues

I could not find an issue relating to it. 

## Pull request checklist
- [x] The target branch is correct (I think - used the default one). 
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/). Not 100%, but a linter should be able to clean that up. 
- [x] This change is covered with tests (or tests aren't necessary for this change). Not yet. 
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release. Not Applicable, AFAIK. 
- [x] CI is green. I am yet to check that. 
