### PR TITLE
FIX Add missing import

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -33,6 +33,7 @@ use SilverStripe\View\Requirements;
 use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * Class BaseElement


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/368

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/13642916064/job/38136393872#step:12:105

`1) DNADesign\Elemental\Tests\BaseElementTest::testGetContentForCmsSearch Error: Class "DNADesign\Elemental\Models\Deprecation" not found`