### PR TITLE
API Deprecate API which was removed or changed in CMS 6.

### DIFF
--- a/src/Controllers/ElementalAreaController.php
+++ b/src/Controllers/ElementalAreaController.php
@@ -29,6 +29,9 @@ class ElementalAreaController extends CMSMain
 
     private static $url_segment = 'elemental-area';
 
+    /**
+     * @deprecated 5.4.0 Will be removed without equivalent functionality to replace it
+     */
     private static $ignore_menuitem = true;
 
     private static $url_handlers = [

--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -11,6 +11,7 @@ use SilverStripe\CMS\Model\VirtualPage;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Extensible;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\ORM\DataExtension;
@@ -297,9 +298,11 @@ class ElementalAreasExtension extends DataExtension
      * Extension hook {@see DataObject::requireDefaultRecords}
      *
      * @return void
+     * @deprecated 5.4.0 Will be renamed to onRequireDefaultRecords()
      */
     public function requireDefaultRecords()
     {
+        Deprecation::noticeWithNoReplacment('5.4.0', 'Will be renamed to onRequireDefaultRecords()');
         if (!$this->supportsElemental()) {
             return;
         }

--- a/src/Extensions/ElementalPageExtension.php
+++ b/src/Extensions/ElementalPageExtension.php
@@ -6,6 +6,7 @@ use DNADesign\Elemental\Models\BaseElement;
 use DNADesign\Elemental\Models\ElementalArea;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\View\Parsers\HTMLValue;
 use SilverStripe\View\SSViewer;
 
@@ -113,8 +114,12 @@ class ElementalPageExtension extends ElementalAreasExtension
         });
     }
 
+    /**
+     * @deprecated 5.4.0 Will be renamed to updateMetaTags()
+     */
     public function MetaTags(&$tags)
     {
+        Deprecation::noticeWithNoReplacment('5.4.0', 'Will be renamed to updateMetaTags()');
         if (!Controller::has_curr()) {
             return;
         }


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/.github/issues/379