### PR TITLE
FIX Remove outdated deprecation notice && MNT Fix broken unit test

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -11,7 +11,6 @@ use SilverStripe\CMS\Model\VirtualPage;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Extensible;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\ORM\DataObject;
@@ -296,11 +295,9 @@ class ElementalAreasExtension extends Extension
      * Extension hook {@see DataObject::requireDefaultRecords}
      *
      * @return void
-     * @deprecated 5.4.0 Will be renamed to onRequireDefaultRecords()
      */
     protected function onRequireDefaultRecords()
     {
-        Deprecation::noticeWithNoReplacment('5.4.0', 'Will be renamed to onRequireDefaultRecords()');
         if (!$this->supportsElemental()) {
             return;
         }

--- a/src/Extensions/ElementalPageExtension.php
+++ b/src/Extensions/ElementalPageExtension.php
@@ -6,7 +6,6 @@ use DNADesign\Elemental\Models\BaseElement;
 use DNADesign\Elemental\Models\ElementalArea;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\View\Parsers\HTMLValue;
 use SilverStripe\View\SSViewer;
 

--- a/tests/Reports/ElementsInUseReportTest.php
+++ b/tests/Reports/ElementsInUseReportTest.php
@@ -9,6 +9,7 @@ use DNADesign\Elemental\Models\ElementContent;
 use DNADesign\Elemental\Reports\ElementsInUseReport;
 use DNADesign\Elemental\Tests\Src\TestElement;
 use DNADesign\Elemental\Tests\Src\TestPage;
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\ORM\DataList;
@@ -91,7 +92,7 @@ class ElementsInUseReportTest extends FunctionalTest
         );
     }
 
-    public function provideXssEscaped(): array
+    public static function provideXssEscaped(): array
     {
         return [
             'xss' => [
@@ -113,9 +114,7 @@ class ElementsInUseReportTest extends FunctionalTest
         ];
     }
 
-    /**
-     * @dataProvider provideXssEscaped
-     */
+    #[DataProvider('provideXssEscaped')]
     public function testXssEscaped(
         string $pageTitle,
         string $elementTitle,


### PR DESCRIPTION
> [!IMPORTANT]
> Multiple commits, DO NOT SQUASH

Fixes https://github.com/silverstripe/silverstripe-elemental/actions/runs/14394094144/job/40366589998

```text
1) DNADesign\Elemental\Tests\Reports\ElementsInUseReportTest::testXssEscaped
The data provider specified for DNADesign\Elemental\Tests\Reports\ElementsInUseReportTest::testXssEscaped is invalid
Data Provider method DNADesign\Elemental\Tests\Reports\ElementsInUseReportTest::provideXssEscaped() is not static
```

Also remove outdated deprecation notice that came along with a merge-up

## Issue
- https://github.com/silverstripe/.github/issues/389