### PR TITLE
TLN Remove duplicate entries

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -66,10 +66,6 @@ en:
     Summary: Summary
     Title: Title
     Type: Type
-  DNADesign\Elemental\Extensions\TopPageElementExtension:
-    has_one_TopPage: 'Top page'
-  DNADesign\Elemental\Extensions\TopPageFluentElementExtension:
-    db_TopPageLocale: 'Top page locale'
   SilverStripe\CMS\Controllers\CMSPageHistoryController:
     PREVIEW: 'Website preview'
   SilverStripe\Versioned\VersionedGridFieldState\VersionedGridFieldState:


### PR DESCRIPTION
Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/15104058598/job/42450127140?pr=92

```text
In YamlReader.php line 42:
                                                                               
  Error parsing YAML, invalid file "/home/runner/work/recipe-kitchen-sink/rec  
  ipe-kitchen-sink/vendor/dnadesign/silverstripe-elemental/lang/en.yml". Mess  
  age: Duplicate key "DNADesign\Elemental\Extensions\TopPageElementExtension"  
   detected at line 69 (near "  has_one_TopPage: 'Top page'").                 
                                                                               

In Parser.php line 340:
                                                                               
  Duplicate key "DNADesign\Elemental\Extensions\TopPageElementExtension" dete  
  cted at line 69 (near "  has_one_TopPage: 'Top page'").          
```

CMS 5 doesn't have the duplicate entry, so it was a fault of bad merge-up.

## Issue

- https://github.com/silverstripe/.github/issues/382