### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/cms": "^6",
         "silverstripe/admin": "^3",
         "silverstripe/versioned": "^3",

--- a/src/Extensions/TopPageElementExtension.php
+++ b/src/Extensions/TopPageElementExtension.php
@@ -319,7 +319,7 @@ class TopPageElementExtension extends Extension
      */
     protected function getTopPageFromCachedData(int $id): ?SiteTree
     {
-        $page = SiteTree::get_by_id($id);
+        $page = SiteTree::get()->setUseCache(true)->byID($id);
 
         if (!$page || !$page->exists()) {
             return null;

--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -676,7 +676,7 @@ JS
         }
 
         $class = DataObject::getSchema()->hasOneComponent($this, 'Parent');
-        $area = ($this->ParentID) ? DataObject::get_by_id($class, $this->ParentID) : null;
+        $area = ($this->ParentID) ? DataObject::get($class)->setUseCache(true)->byID($this->ParentID) : null;
 
         if ($area instanceof ElementalArea && $area->exists()) {
             $page = $area->getOwnerPage();
@@ -934,7 +934,7 @@ JS
 
         if ($page) {
             $class = DataObject::getSchema()->hasOneComponent($this, 'Parent');
-            $area = $this->ParentID ? DataObject::get_by_id($class, $this->ParentID) : null;
+            $area = $this->ParentID ? DataObject::get($class)->setUseCache(true)->byID($this->ParentID) : null;
 
             if ($area) {
                 $has_one = $page->config()->get('has_one');

--- a/src/Models/ElementalArea.php
+++ b/src/Models/ElementalArea.php
@@ -204,14 +204,10 @@ class ElementalArea extends DataObject
             $elementalAreaRelations = $instance->getElementalRelations();
 
             foreach ($elementalAreaRelations as $eaRelationship) {
-                $areaID = $eaRelationship . 'ID';
-
-                $table = DataObject::getSchema()->tableForField($class, $areaID);
-                $baseTable = DataObject::getSchema()->baseDataTable($class);
-                $page = DataObject::get_one($class, [
-                    "\"{$table}\".\"{$areaID}\" = ?" => $this->ID,
-                    "\"{$baseTable}\".\"ClassName\" = ?" => $class
-                ]);
+                $page = DataObject::get($class)->setUseCache(true)->filter([
+                    $eaRelationship . 'ID' => $this->ID,
+                    'ClassName' => $class,
+                ])->first();
 
                 if ($page) {
                     $this->setOwnerPageCached($page);


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
