### PR TITLE
FIX Ensure only a single ElementalArea is created

### DIFF
--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -223,24 +223,27 @@ class ElementalAreasExtension extends Extension
         if (!$this->supportsElemental()) {
             return;
         }
-
-        $elementalAreaRelations = $this->owner->getElementalRelations();
-
+        $owner = $this->getOwner();
+        $elementalAreaRelations = $owner->getElementalRelations();
         $this->ensureElementalAreasExist($elementalAreaRelations);
-
-        $ownerClassName = get_class($this->owner);
+        $ownerClassName = $owner->ClassName;
 
         // Update the OwnerClassName on EA if the class has changed
-        foreach ($elementalAreaRelations as $eaRelation) {
-            $ea = $this->owner->$eaRelation();
-            if ($ea->OwnerClassName !== $ownerClassName) {
-                $ea->OwnerClassName = $ownerClassName;
-                $ea->write();
+        // Do not update if using live versioning mode i.e. publishing,
+        // as it can result in a duplicate ElementalArea being created
+        // Note: checking against LIVE instead of DRAFT as get_stage() can return NULL in unit tests
+        if (Versioned::get_stage() !== Versioned::LIVE) {
+            foreach ($elementalAreaRelations as $relation) {
+                $area = $owner->$relation();
+                if ($area->OwnerClassName !== $ownerClassName) {
+                    $area->OwnerClassName = $ownerClassName;
+                    $area->write();
+                }
             }
         }
 
         if (Config::inst()->get(ElementalAreasExtension::class, 'clear_contentfield')) {
-            $this->owner->Content = '';
+            $owner->Content = '';
         }
     }
 
@@ -278,17 +281,23 @@ class ElementalAreasExtension extends Extension
      */
     public function ensureElementalAreasExist($elementalAreaRelations)
     {
-        foreach ($elementalAreaRelations as $eaRelationship) {
-            $areaID = $eaRelationship . 'ID';
-
-            if (!$this->owner->$areaID) {
-                $area = ElementalArea::create();
-                $area->OwnerClassName = get_class($this->owner);
-                $area->write();
-                $this->owner->$areaID = $area->ID;
-            }
+        $owner = $this->getOwner();
+        // Only create the elemental area on draft stage
+        // Note: checking against LIVE instead of DRAFT as get_stage() can return NULL in unit tests
+        if (Versioned::get_stage() === Versioned::LIVE) {
+            return $owner;
         }
-        return $this->owner;
+        foreach ($elementalAreaRelations as $relation) {
+            $field = "{$relation}ID";
+            if ($owner->$field) {
+                continue;
+            }
+            $area = ElementalArea::create();
+            $area->OwnerClassName = $owner->ClassName;
+            $area->write();
+            $owner->$relation = $area;
+        }
+        return $owner;
     }
 
     /**

--- a/tests/Extensions/ElementalAreasExtensionTest.php
+++ b/tests/Extensions/ElementalAreasExtensionTest.php
@@ -15,6 +15,7 @@ use DNADesign\Elemental\Tests\Src\TestVersionedDataObject;
 use DNADesign\Elemental\Extensions\ElementalAreasExtension;
 use SilverStripe\ORM\DB;
 use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\ORM\DataObject;
 
 class ElementalAreasExtensionTest extends SapphireTest
 {
@@ -46,6 +47,22 @@ class ElementalAreasExtensionTest extends SapphireTest
                 TestUnusedElement::class,
             ])
             ->set('disallowed_elements', []);
+    }
+
+    protected function tearDown(): void
+    {
+        // For whatever reason, tables are not being properly cleaned between tests
+        // This was noticed when asserting an empty database table in testSingleElementalAreaCreated()
+        // where there was still data in it from testRequireDefaultRecords()
+        $schema = DataObject::getSchema();
+        $dataClasses = [TestVersionedDataObject::class, ElementalArea::class];
+        foreach ($dataClasses as $dataClass) {
+            $draftTable = $schema->baseDataTable($dataClass);
+            $liveTable = "{$draftTable}_Live";
+            DB::query("TRUNCATE $draftTable");
+            DB::query("TRUNCATE $liveTable");
+        }
+        parent::tearDown();
     }
 
     public function testGetElementalTypesSortsAlphabetically()
@@ -141,5 +158,46 @@ class ElementalAreasExtensionTest extends SapphireTest
         $this->assertSame(ElementalArea::get()->max('ID'), $object->ElementalAreaID);
         // assert that we didn't accidentally publish the modified object
         $this->assertTrue($object->isModifiedOnDraft());
+    }
+
+    /**
+     * Tests that only a single elemental area is created during ElementalAreasExtension::onBeforeWrite()
+     */
+    public function testSingleElementalAreaCreated(): void
+    {
+        $this->assertCountsForTestSingleElementalAreaCreated(0, 0, 0, 0, 0);
+        $object = new TestVersionedDataObject();
+        $object->Title = 'abc';
+        $object->write();
+        $areaID = $object->ElementalAreaID;
+        $this->assertTrue($areaID > 0);
+        $this->assertCountsForTestSingleElementalAreaCreated(1, 0, 1, 0, $areaID);
+        $object->publishSingle();
+        $this->assertCountsForTestSingleElementalAreaCreated(1, 1, 1, 1, $areaID);
+    }
+
+    private function assertCountsForTestSingleElementalAreaCreated(
+        int $expectedDraftTotalCount,
+        int $expectedLiveTotalCount,
+        int $expectedDraftCount,
+        int $expectedLiveCount,
+        int $areaID,
+    ): void {
+        $schema = (new DataObject)->getSchema();
+        $draftAreaTable = $schema->baseDataTable(TestVersionedDataObject::class);
+        $liveAreaTable = "{$draftAreaTable}_Live";
+        $draftTotalCount = DB::query("SELECT COUNT(*) as c FROM $draftAreaTable")->record()['c'];
+        $liveTotalCount = DB::query("SELECT COUNT(*) as c FROM $liveAreaTable")->record()['c'];
+        $this->assertSame($expectedDraftTotalCount, $draftTotalCount);
+        $this->assertSame($expectedLiveTotalCount, $liveTotalCount);
+        if ($areaID === 0) {
+            return;
+        }
+        $sql = "SELECT COUNT(*) as c FROM $draftAreaTable WHERE ID = ?";
+        $draftCount = DB::prepared_query($sql, [$areaID])->record()['c'];
+        $sql = "SELECT COUNT(*) as c FROM $liveAreaTable WHERE ID = ?";
+        $liveCount = DB::prepared_query($sql, [$areaID])->record()['c'];
+        $this->assertSame($expectedDraftCount, $draftCount);
+        $this->assertSame($expectedLiveCount, $liveCount);
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-elemental/issues/1362

Duplicate elemental areas were being created when a page was being created for the first time because onBeforeWrite() was being called for both the draft and live record creation.  The duplicate entry was being created because when the reading mode was set to live

```php
            $ea = $this->owner->$eaRelation();
            if ($ea->OwnerClassName !== $ownerClassName) {
                $ea->OwnerClassName = $ownerClassName;
                $ea->write();
```
`$ea` would get an ElementalArea (non-persisted object i.e. ID = 0) and then `write()` it