### PR TITLE
MNT Make behat test more robust

### DIFF
--- a/tests/Behat/features/file-upload.feature
+++ b/tests/Behat/features/file-upload.feature
@@ -43,6 +43,8 @@ Feature: Files can be saved in and removed from elemental blocks
     And I press the "View actions" button
     # same file, so we shouldn't see the button
     Then I should not see the save button for block 1
+    # Close menu
+    When I press the "View actions" button
     # Add a different file
     And I click on the "#Form_ElementForm_1 .uploadfield-item__remove-btn" element
     When I click "Choose existing" in the "#Form_ElementForm_1 .uploadfield" element


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/454

Fixes [issue](https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/18177917673/job/51752047586#step:12:353) on `6` branch where the menu is blocking the remove button on the upload field

<img width="1044" height="785" alt="image" src="https://github.com/user-attachments/assets/12583b48-acdf-41a3-9000-43fd185bb3d5" />

This issue only seems to be affecting the `6` branch, though based on the screen shot it may be something to do with chrome, so may affect older branches so I've targetted `5.4` to be sure

Run the merge-up action on the repo after merging