### PR TITLE
ENH PHP 8.5 Support

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -1144,7 +1144,7 @@ JS
      */
     public function getStyleVariant()
     {
-        $style = $this->Style;
+        $style = $this->Style ?? '';
         $styles = $this->config()->get('styles');
 
         if (isset($styles[$style])) {


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- Using null as an array offset or when calling array_key_exists() is now deprecated.
