### PR TITLE
MNT Test history tab with non-previewable parent

### DIFF
--- a/tests/Behat/features/add-block-element-to-data-object.feature
+++ b/tests/Behat/features/add-block-element-to-data-object.feature
@@ -43,3 +43,11 @@ Feature: Add elements in the CMS DataObject
         And the "Content" field should contain "<p>New sample content</p>"
         Then I press the "Navigate up a folder" button
         Then I should see "New Elemental Behat Test Title" as the title for block 1
+
+    # very quick check that history tab is broadly working
+    Given I click on block 1
+        When I click on "History" in the header tabs
+        And I wait for 3 seconds until I see the ".history-viewer__table" element
+        And I click on the ".history-viewer__row" element
+        And I wait for 3 seconds until I see the "#Form_versionForm" element
+        Then I should see "New sample content"


### PR DESCRIPTION
Requires https://github.com/silverstripe/silverstripe-versioned-admin/pull/451 to be merged first for CI to go green.

## Issue

- https://github.com/silverstripe/silverstripe-versioned-admin/issues/450