### PR TITLE
FIX Get valid CMS edit link for non-page data object

### DIFF
--- a/src/Models/BaseElement.php
+++ b/src/Models/BaseElement.php
@@ -916,7 +916,7 @@ JS
         if ($page instanceof SiteTree) {
             $link = $page->CMSEditLink();
         } elseif (ClassInfo::hasMethod($page, 'CMSEditLink')) {
-            $link = Controller::join_links($page->CMSEditLink(), 'ItemEditForm');
+            $link = $page->CMSEditLink();
         }
         // In-line editable blocks should just take you to the page.
         // Editable ones should add the suffix for detail form.
@@ -931,10 +931,12 @@ JS
                     $this->ID,
                     'edit'
                 );
-            } else {
-                // If $page is not a Page, then generate $link base on $page->CMSEditLink()
+            } elseif ($link) {
+                // If $page is not a Page, then generate $link based on $page->CMSEditLink()
+                // for a gridfield edit form
                 return Controller::join_links(
                     $link,
+                    'ItemEditForm',
                     'field',
                     $relationName,
                     'item',

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -310,43 +310,51 @@ class BaseElementTest extends FunctionalTest
     public function getElementCMSLinkDataProvider()
     {
         return [
-            // Element in DataObject with $directLink === true
-            'element1' => [
+            // Regular DataObject as parent
+            'DataObject using $directLink' => [
                 TestElement::class,
                 'elementDataObject1',
-                'http://localhost/admin/1/ItemEditForm/field/ElementalArea/item/',
+                '@admin/[0-9]+/ItemEditForm/field/ElementalArea/item/[0-9]+/edit/?$@',
                 true
             ],
-            // Element in DataObject with $inline_editable = false
-            'element2' => [
+            'DataObject not inline editable' => [
                 TestElementDataObject::class,
                 'testElementDataObject1',
-                'http://localhost/admin/1/ItemEditForm/field/ElementalArea/item/',
+                '@admin/[0-9]+/ItemEditForm/field/ElementalArea/item/[0-9]+/edit/?$@',
             ],
-            // Element in DataObject with $inline_editable = true
-            'element3' => [
+            'DataObject is inline editable' => [
                 ElementContent::class,
                 'contentDataObject1',
-                'http://localhost/admin/1/ItemEditForm',
+                '@admin/[0-9]+/?$@',
             ],
-            // Element in Page with $inline_editable = true
-            'element4' => [
+            // SiteTree subclass as parent
+            'Page using $directLink' => [
                 ElementContent::class,
                 'content1',
-                'http://localhost/admin/pages/edit/show/1',
-            ],
-            // Element in DataObject with $directLink === true
-            'element5' => [
-                ElementContent::class,
-                'content1',
-                'admin/pages/edit/EditForm/1/field/ElementalArea/item/1/edit',
+                '@admin/pages/edit/EditForm/[0-9]+/field/ElementalArea/item/[0-9]+/edit/?$@',
                 true
             ],
-            // DataObject without CMSEditLink method
-            'element6' => [
+            'page not inline editable' => [
+                TestElementDataObject::class,
+                'testElementDataObject2',
+                '@admin/pages/edit/EditForm/[0-9]+/field/ElementalArea/item/[0-9]+/edit/?$@',
+            ],
+            'Page is inline editable' => [
+                ElementContent::class,
+                'content1',
+                '@admin/pages/edit/show/[0-9]+/?$@',
+            ],
+            // DataObject without CMSEditLink method implemented
+            'No CMSEditLink method (inline editable)' => [
                 TestElement::class,
                 'elementDataObject2',
                 null
+            ],
+            'Not CMSEditLink method (using directLink)' => [
+                TestElement::class,
+                'elementDataObject2',
+                null,
+                true
             ],
         ];
     }
@@ -360,9 +368,9 @@ class BaseElementTest extends FunctionalTest
         $editLink = $object->CMSEditLink($directLink);
 
         if ($link) {
-            $this->assertStringContainsString($link, $editLink);
+            $this->assertMatchesRegularExpression($link, $editLink);
         } else {
-            $this->assertNull($link);
+            $this->assertNull($editLink);
         }
     }
 

--- a/tests/ElementalAreaDataObjectTest.yml
+++ b/tests/ElementalAreaDataObjectTest.yml
@@ -14,6 +14,9 @@ DNADesign\Elemental\Models\ElementalArea:
   areaDataObject5:
     Title: Area 5
     OwnerClassName: DNADesign\Elemental\Tests\Src\TestPreviewableDataObjectWithLink
+  areaDataObject6:
+    Title: Area 6
+    OwnerClassName: DNADesign\Elemental\Tests\Src\TestPage
 
 DNADesign\Elemental\Tests\Src\TestDataObjectWithCMSEditLink:
   dataObject1:
@@ -66,6 +69,10 @@ DNADesign\Elemental\Tests\Src\TestElementDataObject:
     Title: Test Element inline-editable
     TestValue: 'Hello Test'
     ParentID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject1
+  testElementDataObject2:
+    Title: Test Element inline-editable
+    TestValue: 'Hello Test'
+    ParentID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject6
 
 DNADesign\Elemental\Models\ElementContent:
   contentDataObject1:
@@ -80,3 +87,8 @@ DNADesign\Elemental\Tests\Src\TestMultipleHtmlFieldsElement:
   multiHtmlFields2:
     Field1: '<p>id="not-anchor"</p>'
     Field2: '<p>name="not-anchor2"</p>'
+
+DNADesign\Elemental\Tests\Src\TestPage:
+  testpage1:
+    Title: Test Elemental
+    ElementalAreaID: =>DNADesign\Elemental\Models\ElementalArea.areaDataObject6


### PR DESCRIPTION
The edit link for an elemental block on a DataObject that didn't subclass SiteTree was incorrectly created.

## Issue

- https://github.com/silverstripe/silverstripe-elemental/issues/1399