### PR TITLE
MNT Resolve timing issue in behat

### DIFF
--- a/tests/Behat/features/move-element.feature
+++ b/tests/Behat/features/move-element.feature
@@ -147,6 +147,7 @@ Feature: Move elements in the CMS
     And I select "SilverStripe\FrameworkTest\Elemental\Model\MultiElementalBehatTestObject" from "ParentClass"
     And I click on the "#Form_ElementForm_3_move_ParentID" element
     And I click on the ".ss-searchable-dropdown-field__option:nth-of-type(2)" element
+    And I wait for 1 second
     And I select "ElementalArea2" from "ElementalAreaRelation"
     And I press the "Move" button
     And I should see a "Moved block 'Lorem' successfully" success toast with these actions: Go to edit form for new block parent


### PR DESCRIPTION
Looks like there's a timing issue here. Putting a screenshot after every step showed it was _just barely_ enough time for the network request to complete and the form to update before swapping the elemental area, and was passing. That indicates that the time it took to take a screenshot was enough time to let stuff resolve.

I'm guessing some combination of PHP 8.5 and MySQL 8.4 is causing things to run with slightly different timing than PHP 8.3 and MySQL 8.0.

Fixes https://github.com/silverstripe/silverstripe-elemental/actions/runs/21967740909/job/63462200606
> And I should see a "Moved block 'Lorem' successfully" success toast with these actions: Go to edit form for new block parent # SilverStripe\Framework\Tests\Behaviour\CmsUiContext::iShouldSeeAToastWithAction()
      No toast container found with text: Moved block 'Lorem' successfully
      Failed asserting that 'Not found' is null.


## Issue

- https://github.com/silverstripe/.github/issues/476