### PR TITLE
DOC Correct typos with codespell

### DIFF
--- a/docs/en/02_advanced_setup.md
+++ b/docs/en/02_advanced_setup.md
@@ -33,7 +33,7 @@ class BlockPage extends Page
 ```
 
 > [!IMPORTANT]
-> If you programatically publish a `Page` or a `DataObject` that has [`ElementalPageExtension`](api:DNADesign\Elemental\Extensions\ElementalPageExtension)
+> If you programmatically publish a `Page` or a `DataObject` that has [`ElementalPageExtension`](api:DNADesign\Elemental\Extensions\ElementalPageExtension)
 > applied to it, ensure that you call [`RecursivePublishable::publishRecursive()`](api:SilverStripe\Versioned\RecursivePublishable::publishRecursive())
 > and not [`Versioned::publishSingle()`](api:SilverStripe\Versioned\Versioned::publishSingle())
 > to ensure the `ElementalArea` and its child elements are published correctly.

--- a/src/Controllers/ElementalAreaController.php
+++ b/src/Controllers/ElementalAreaController.php
@@ -472,7 +472,7 @@ class ElementalAreaController extends FormSchemaController
     {
         $request = $this->getRequest();
 
-        // Check security token for non-view operation - note token is pased in POST body, not headers
+        // Check security token for non-view operation - note token is passed in POST body, not headers
         if (!SecurityToken::inst()->checkRequest($request)) {
             $this->jsonError(400);
         }

--- a/src/Extensions/ElementalAreasExtension.php
+++ b/src/Extensions/ElementalAreasExtension.php
@@ -308,7 +308,7 @@ class ElementalAreasExtension extends Extension implements Resettable
             $area->OwnerClassName = $owner->ClassName;
             // Do not attempt to set the ElementalArea.TopPageID if the owner (e.g. Page)
             // has not yet been persisted to the database, as this will cause a potentially
-            // large number of unneccessary database queries
+            // large number of unnecessary database queries
             if (!$owner->isInDB() && $area::has_extension(TopPageElementExtension::class)) {
                 /** @var ElementalArea&TopPageElementExtension $area */
                 $area->withoutCallingSetTopPage(fn() => $area->write());

--- a/src/Extensions/TopPageElementExtension.php
+++ b/src/Extensions/TopPageElementExtension.php
@@ -182,7 +182,7 @@ class TopPageElementExtension extends Extension
             return;
         }
 
-        // set the page to properties in case this object is re-used later
+        // set the page to properties in case this object is reused later
         $this->assignTopPage($page);
         $this->saveChanges();
     }

--- a/src/Forms/EditFormFactory.php
+++ b/src/Forms/EditFormFactory.php
@@ -69,7 +69,7 @@ class EditFormFactory extends DefaultFormFactory
         foreach ($compositeValidator->getValidatorsByType(RequiredFieldsValidator::class) as $validator) {
             $requiredFields = $validator->getRequired();
             foreach ($requiredFields as $requiredField) {
-                // Add more required fields with appendend field prefixes
+                // Add more required fields with appended field prefixes
                 // this is done so that front end validation works, at least for RequiredFieldsValidator
                 // you'll end up with two sets of required fields:
                 // - Title -- used for backend validation when inline saving an element

--- a/tests/Behat/features/inline-block-validation.feature
+++ b/tests/Behat/features/inline-block-validation.feature
@@ -27,7 +27,7 @@ Feature: Blocks are validated when inline saving individual blocks
     And I click on the ".element-editor__actions-save" element
     And I dismiss all toasts
 
-  # Note that each test is split into a seperate scenario instead a large single scenario which would
+  # Note that each test is split into a separate scenario instead a large single scenario which would
   # be faster due to a limitation with behat testing react where changing the value of a field can
   # sometimes lead to the value of field being suffixed rather than replaced
 

--- a/tests/Behat/features/versioned-status-block-element.feature
+++ b/tests/Behat/features/versioned-status-block-element.feature
@@ -1,7 +1,7 @@
 @javascript @retry @job6
 Feature: Add elements in the CMS and see currunt status of elements
   As a CMS user
-  I want to see versined status of Element blocks
+  I want to see versioned status of Element blocks
 
   Background:
     Given I add an extension "DNADesign\Elemental\Extensions\ElementalPageExtension" to the "Page" class

--- a/tests/Extensions/ElementalAreasExtensionTest.php
+++ b/tests/Extensions/ElementalAreasExtensionTest.php
@@ -132,7 +132,7 @@ class ElementalAreasExtensionTest extends SapphireTest
 
     public function testRequireDefaultRecords()
     {
-        // Explicity set the reading mode to Stage.Stage because there is logic in
+        // Explicitly set the reading mode to Stage.Stage because there is logic in
         // ElementalAreasExtension::allowAlteringElementalArea() that requires it,
         // and the default reading mode for unit tests is blank string
         Versioned::set_stage(Versioned::DRAFT);

--- a/tests/Forms/MoveFormFactoryTest.php
+++ b/tests/Forms/MoveFormFactoryTest.php
@@ -410,7 +410,7 @@ class MoveFormFactoryTest extends SapphireTest
                     TestPreviewableDataObjectWithLink::class => TestPreviewableDataObjectWithLink::class,
                 ],
             ],
-            'ignore some classes incl implicity ignoring subclasses' => [
+            'ignore some classes incl implicitly ignoring subclasses' => [
                 'recordClass' => TestElementContent::class,
                 'configToSet' => [
                     ElementalAreasExtension::class => [

--- a/tests/Tasks/MigrateContentToElementTest.php
+++ b/tests/Tasks/MigrateContentToElementTest.php
@@ -33,7 +33,7 @@ class MigrateContentToElementTest extends SapphireTest
     {
         TestPage::create()->flushCache();
         parent::setUp();
-        // Explicity set the reading mode to Stage.Stage because there is logic in
+        // Explicitly set the reading mode to Stage.Stage because there is logic in
         // ElementalAreasExtension::allowAlteringElementalArea() that requires it,
         // and the default reading mode for unit tests is blank string
         Versioned::set_stage(Versioned::DRAFT);

--- a/tests/TopPage/TopPageTest.php
+++ b/tests/TopPage/TopPageTest.php
@@ -118,7 +118,7 @@ class TopPageTest extends SapphireTest
 
     public function testNewPage(): void
     {
-        // Explicity set the reading mode to Stage.Stage because there is logic in
+        // Explicitly set the reading mode to Stage.Stage because there is logic in
         // ElementalAreasExtension::allowAlteringElementalArea() that requires it,
         // and the default reading mode for unit tests is blank string
         Versioned::set_stage(Versioned::DRAFT);


### PR DESCRIPTION
## Description
Source code (4 files):
- appendend → appended (EditFormFactory.php)
- unneccessary → unnecessary (ElementalAreasExtension.php)
- re-used → reused (TopPageElementExtension.php)
- pased → passed (ElementalAreaController.php)

Tests (6 files):
- Explicity → Explicitly (MigrateContentToElementTest.php, ElementalAreasExtensionTest.php, TopPageTest.php)
- implicity → implicitly (MoveFormFactoryTest.php)
- seperate → separate (inline-block-validation.feature)
- versined → versioned (versioned-status-block-element.feature)

Documentation (1 file):
- programatically → programmatically (02_advanced_setup.md)

All changes are to comments, documentation, and test files. No functional code changes.

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
