### PR TITLE
DOC: fix relative path to userguide/index.md from docs/en/index.md

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -16,7 +16,7 @@ of rather than a single text field. Features supported:
 The module provides basic markup for each of the elements but you will likely need to provide your own styles. Replace
 the `$Content` variable with `$ElementalArea` in your page templates, and rely on the markup of the individual elements.
 
-For a more detailed overview of using this module, please see [the User help guides](docs/en/userguide/index.md).
+For a more detailed overview of using this module, please see [the User help guides](userguide/index.md).
 
 ## Installation
 


### PR DESCRIPTION
## Summary

`docs/en/index.md` links to the User help guides using `docs/en/userguide/index.md`, which is a root-relative path rather than the relative path expected from the file's own location. When rendered on the Silverstripe docs site the link resolves to `docs/en/docs/en/userguide/index.md` and 404s.

Fixed by switching to the correct relative path `userguide/index.md` (the `userguide/` folder is a sibling of `index.md`).

Closes #1425

## Testing

Documentation-only change. Verified `docs/en/userguide/index.md` exists as a sibling directory of `docs/en/index.md`, so the new relative path resolves correctly both on GitHub and on the rendered docs site.